### PR TITLE
Add Manhattan/Chebyshev distance and line-of-sight public API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Releases are driven by interactive bash scripts in `ci/` (macOS-oriented; uses B
 
 ### Geometry helpers — `Source/Pathfinder_Geometry.cs`
 
-Public spatial queries that don't produce a path: `static GetManhattanDistance`/`GetChebyshevDistance` (pure integer metrics over `Coordinate`, no grid state) and the instance `HasLineOfSight(from, to)`. LOS pins `_cells` and delegates to the existing private Bresenham `HasLineOfSight(from, to, Cell*)` (also used by string-pulling smoothing in `Pathfinder_PathSmoothing.cs`) — a cell between the endpoints blocks sight when not walkable, or occupied when `IsCalculatingOccupiedCells` is set. Endpoints are never tested; the ray is single-cell (agent size ignored).
+Public spatial queries that don't produce a path: `static GetManhattanDistance`/`GetChebyshevDistance` (pure integer metrics over `Coordinate`, no grid state) and the instance `HasLineOfSight(from, to, LineOfSightMode mode = BlockedByUnwalkableCells)`. LOS pins `_cells` and delegates to the private Bresenham `HasLineOfSight(from, to, Cell*, mode)` in `Pathfinder_PathSmoothing.cs` (also used by string-pulling smoothing, which always passes `BlockedByUnwalkableCells`). The per-cell test is `IsLineOfSightBlocked`: under `BlockedByUnwalkableCells` a non-walkable cell blocks; under `IgnoreUnwalkableCells` it's transparent (see-through terrain). In **both** modes an occupied cell blocks when `IsCalculatingOccupiedCells` is set — the mode governs walkability only, occupancy stays orthogonal. Endpoints are never tested; the ray is single-cell (agent size ignored). `LineOfSightMode` is a public enum in `Source/Data/`.
 
 ### Open set — `Source/Internal/UnsafePriorityQueue.cs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Releases are driven by interactive bash scripts in `ci/` (macOS-oriented; uses B
 
 ## Architecture
 
-### Core algorithm — `Source/Pathfinder.cs` (+ `Pathfinder_PathSmoothing.cs`, `Pathfinder_Reachability.cs`)
+### Core algorithm — `Source/Pathfinder.cs` (+ `Pathfinder_PathSmoothing.cs`, `Pathfinder_Reachability.cs`, `Pathfinder_Geometry.cs`)
 
 `Pathfinder` is a `sealed unsafe partial class`. The hot path operates on a flat `Cell[]` via a raw `Cell*` pointer (`fixed`/`stackalloc`), indexed as `x * Height + y` (see `GetCell`). Key performance design points to preserve when editing:
 
@@ -80,6 +80,10 @@ Releases are driven by interactive bash scripts in `ci/` (macOS-oriented; uses B
 - **Four constructors → `InitializationMode`** (`CellsArray`, `CellHoldersArray`, `CellsMatrix`, `CellHoldersMatrix`). `InitializeCellsArray()` dispatches to the matching `TryInitializing...` method to flatten the caller's representation into `_cells` before each search. The `Cell[]`-array mode sorts in place (`Utils.CellsComparison`) and is the only mode that does **not** pool/copy. `CellsComparison` sorts **X-major then Y-minor** so the sorted layout matches `GetCell`'s `x * Height + y` indexing (the matrix/holder modes write cells at `Coordinate.X * Height + Coordinate.Y`); keep all four modes consistent or neighbor adjacency silently transposes.
 - **`stackalloc Cell*[8]` neighbors**, populated cardinal-first then diagonal. Diagonal inclusion respects `IsDiagonalMovementEnabled` and `IsMovementBetweenCornersEnabled` (corner-cutting). Agent `Size > 1` triggers a clearance scan in `GetWalkableLocation`.
 - Heuristic is **Manhattan distance** (`GetH`). G-score folds in per-cell `Weight` (when `IsCellWeightEnabled`) and straight-vs-diagonal travel multipliers.
+
+### Geometry helpers — `Source/Pathfinder_Geometry.cs`
+
+Public spatial queries that don't produce a path: `static GetManhattanDistance`/`GetChebyshevDistance` (pure integer metrics over `Coordinate`, no grid state) and the instance `HasLineOfSight(from, to)`. LOS pins `_cells` and delegates to the existing private Bresenham `HasLineOfSight(from, to, Cell*)` (also used by string-pulling smoothing in `Pathfinder_PathSmoothing.cs`) — a cell between the endpoints blocks sight when not walkable, or occupied when `IsCalculatingOccupiedCells` is set. Endpoints are never tested; the ray is single-cell (agent size ignored).
 
 ### Open set — `Source/Internal/UnsafePriorityQueue.cs`
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ if (pathfinder.HasLineOfSight(shooter, target))
 {
     Debug.Log("Clear shot!");
 }
+
+// Or see through terrain that blocks movement but not vision (water, pits, glass):
+pathfinder.HasLineOfSight(shooter, target, LineOfSightMode.IgnoreUnwalkableCells);
 ```
 
 See the [Distance and Line of Sight guide](docs/guides/distance-and-line-of-sight.md) for details.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A high-performance A* implementation for 2D grid navigation, designed primarily 
 - Allocates memory only when necessary to maximize performance
 - Designed for 2D grid-based navigation in games
 - Movement-range queries (`GetReachable`) for "where can this unit move?" mechanics
+- Distance metrics (Manhattan, Chebyshev) and line-of-sight checks for range and visibility logic
 - First-class support for Unity with dedicated integration components
 - Fully usable in any standalone .NET application
 - Extensively tested with comprehensive unit tests
@@ -159,6 +160,24 @@ foreach (var cell in range.Cells)
     Debug.Log($"{cell.Coordinate} reachable for {cell.Cost}");
 }
 ```
+
+### Distance and line of sight
+
+For range checks and visibility — without computing a full path — use the distance metrics and the line-of-sight test:
+
+```csharp
+// Pure grid distances (static, allocation-free)
+int manhattan = Pathfinder.GetManhattanDistance(start, end); // |dx| + |dy|
+int chebyshev = Pathfinder.GetChebyshevDistance(start, end);  // max(|dx|, |dy|)
+
+// Is the target visible (no walls in between)?
+if (pathfinder.HasLineOfSight(shooter, target))
+{
+    Debug.Log("Clear shot!");
+}
+```
+
+See the [Distance and Line of Sight guide](docs/guides/distance-and-line-of-sight.md) for details.
 
 ### Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ MPath provides a robust implementation of the A* pathfinding algorithm with seve
 - [Agent Configuration](guides/agent-configuration.md) - Working with pathfinding agents
 - [Pathfinder Settings](guides/pathfinder-settings.md) - Customizing pathfinding behavior
 - [Movement Range](guides/movement-range.md) - Finding every cell an agent can reach within a budget
+- [Distance and Line of Sight](guides/distance-and-line-of-sight.md) - Grid distance metrics and visibility checks
 - [Unity Integration](guides/unity-example.md) - Detailed guide for Unity projects
 - [Performance Considerations](guides/performance.md) - Optimizing for different scenarios
 - [API Reference](api/README.md) - Detailed API documentation

--- a/docs/api/LineOfSightMode.md
+++ b/docs/api/LineOfSightMode.md
@@ -1,0 +1,34 @@
+# LineOfSightMode Enum
+
+**Namespace:** `Migs.MPath.Core.Data`
+
+Controls how [`Pathfinder.HasLineOfSight`](Pathfinder.md) treats cells that are not walkable when tracing the line between two coordinates.
+
+## Values
+
+| Value | Description |
+|-------|-------------|
+| `BlockedByUnwalkableCells` | **(default)** A non-walkable cell between the endpoints blocks line of sight, matching how walls interrupt vision in most grid games. |
+| `IgnoreUnwalkableCells` | Non-walkable cells are treated as transparent and do not block line of sight. Use this when an obstacle blocks movement but not vision (water, a pit, a chasm, a glass wall). |
+
+## Usage Example
+
+```csharp
+// Walls block the shot (default).
+bool blockedByWalls = pathfinder.HasLineOfSight(shooter, target);
+
+// Terrain is see-through; only occupants can still block.
+bool ignoringTerrain = pathfinder.HasLineOfSight(shooter, target, LineOfSightMode.IgnoreUnwalkableCells);
+```
+
+## Remarks
+
+- The mode **only** governs walkability. Occupancy is handled separately: when
+  `IsCalculatingOccupiedCells` is enabled, an occupied cell blocks sight under **either** mode. This makes
+  "ignore terrain, but units still block" expressible by combining `IgnoreUnwalkableCells` with occupancy.
+- The endpoints themselves are never tested, so a target standing on a blocked or occupied cell can still be
+  seen regardless of mode.
+- The default value (`BlockedByUnwalkableCells`) is `0`, so `default(LineOfSightMode)` preserves the
+  blocking behaviour.
+
+See the [Distance and Line of Sight guide](../guides/distance-and-line-of-sight.md) for the full picture.

--- a/docs/api/Pathfinder.md
+++ b/docs/api/Pathfinder.md
@@ -19,6 +19,9 @@ A high-performance A* pathfinding implementation for grid-based environments.
 |--------|-------------|
 | `PathResult GetPath(IAgent agent, Coordinate from, Coordinate to)` | Calculates a path from starting position to destination. |
 | `RangeResult GetReachable(IAgent agent, Coordinate from, float budget)` | Finds every cell whose cheapest path cost from the origin is within the budget. |
+| `bool HasLineOfSight(Coordinate from, Coordinate to)` | Returns whether an unobstructed straight line connects two cells. |
+| `static int GetManhattanDistance(Coordinate from, Coordinate to)` | Manhattan (taxicab) distance `\|dx\| + \|dy\|`. |
+| `static int GetChebyshevDistance(Coordinate from, Coordinate to)` | Chebyshev (chessboard) distance `max(\|dx\|, \|dy\|)`. |
 | `Pathfinder EnablePathCaching(IPathCaching pathCachingHandler = null)` | Enables path caching with optional custom implementation. |
 | `Pathfinder DisablePathCaching()` | Disables path caching. |
 | `Pathfinder InvalidateCache()` | Clears the current path cache without disabling caching. |
@@ -73,4 +76,32 @@ foreach (var cell in range.Cells)
 }
 ```
 
-See [RangeResult](RangeResult.md) and [ReachableCell](ReachableCell.md) for the returned types. Like `PathResult`, a `RangeResult` must be disposed (use `using`). 
+See [RangeResult](RangeResult.md) and [ReachableCell](ReachableCell.md) for the returned types. Like `PathResult`, a `RangeResult` must be disposed (use `using`).
+
+### Distance and line of sight
+
+For lightweight spatial queries that don't need a full path, `Pathfinder` exposes grid metrics and a line-of-sight test:
+
+- `GetManhattanDistance(from, to)` — the taxicab distance `|dx| + |dy|` (cardinal steps). This is the metric used by the A* heuristic.
+- `GetChebyshevDistance(from, to)` — the chessboard distance `max(|dx|, |dy|)` (steps when diagonals cost the same as cardinals).
+- `HasLineOfSight(from, to)` — whether a straight line between two cells is unobstructed.
+
+The two distance methods are `static`, pure, and allocation-free — they only read the coordinates and ignore walls, weights and movement settings:
+
+```csharp
+var manhattan = Pathfinder.GetManhattanDistance(new Coordinate(1, 1), new Coordinate(4, 5)); // 7
+var chebyshev = Pathfinder.GetChebyshevDistance(new Coordinate(1, 1), new Coordinate(4, 5)); // 4
+```
+
+`HasLineOfSight` traces a Bresenham line between the two cells and returns `false` if any cell **between** them is not walkable (or, when `IsCalculatingOccupiedCells` is enabled, is occupied). It is an O(distance) query that allocates nothing — handy for fog-of-war, ranged attacks or skipping pathfinding when a target is in plain sight.
+
+```csharp
+using var pathfinder = new Pathfinder(cells, 10, 10);
+
+if (pathfinder.HasLineOfSight(new Coordinate(2, 2), new Coordinate(7, 5)))
+{
+    // Nothing blocks the shot.
+}
+```
+
+The endpoints themselves are never tested for walkability, so a target standing on a blocked or occupied cell can still be "seen". Agent size is not considered — the check traces a single-cell ray. A cell always has line of sight to itself, and an out-of-range coordinate throws `ArgumentException`. 

--- a/docs/api/Pathfinder.md
+++ b/docs/api/Pathfinder.md
@@ -19,7 +19,7 @@ A high-performance A* pathfinding implementation for grid-based environments.
 |--------|-------------|
 | `PathResult GetPath(IAgent agent, Coordinate from, Coordinate to)` | Calculates a path from starting position to destination. |
 | `RangeResult GetReachable(IAgent agent, Coordinate from, float budget)` | Finds every cell whose cheapest path cost from the origin is within the budget. |
-| `bool HasLineOfSight(Coordinate from, Coordinate to)` | Returns whether an unobstructed straight line connects two cells. |
+| `bool HasLineOfSight(Coordinate from, Coordinate to, LineOfSightMode mode = BlockedByUnwalkableCells)` | Returns whether an unobstructed straight line connects two cells. |
 | `static int GetManhattanDistance(Coordinate from, Coordinate to)` | Manhattan (taxicab) distance `\|dx\| + \|dy\|`. |
 | `static int GetChebyshevDistance(Coordinate from, Coordinate to)` | Chebyshev (chessboard) distance `max(\|dx\|, \|dy\|)`. |
 | `Pathfinder EnablePathCaching(IPathCaching pathCachingHandler = null)` | Enables path caching with optional custom implementation. |
@@ -93,7 +93,7 @@ var manhattan = Pathfinder.GetManhattanDistance(new Coordinate(1, 1), new Coordi
 var chebyshev = Pathfinder.GetChebyshevDistance(new Coordinate(1, 1), new Coordinate(4, 5)); // 4
 ```
 
-`HasLineOfSight` traces a Bresenham line between the two cells and returns `false` if any cell **between** them is not walkable (or, when `IsCalculatingOccupiedCells` is enabled, is occupied). It is an O(distance) query that allocates nothing — handy for fog-of-war, ranged attacks or skipping pathfinding when a target is in plain sight.
+`HasLineOfSight` traces a Bresenham line between the two cells and returns `false` if any cell **between** them blocks sight. It is an O(distance) query that allocates nothing — handy for fog-of-war, ranged attacks or skipping pathfinding when a target is in plain sight.
 
 ```csharp
 using var pathfinder = new Pathfinder(cells, 10, 10);
@@ -104,4 +104,11 @@ if (pathfinder.HasLineOfSight(new Coordinate(2, 2), new Coordinate(7, 5)))
 }
 ```
 
-The endpoints themselves are never tested for walkability, so a target standing on a blocked or occupied cell can still be "seen". Agent size is not considered — the check traces a single-cell ray. A cell always has line of sight to itself, and an out-of-range coordinate throws `ArgumentException`. 
+By default (`LineOfSightMode.BlockedByUnwalkableCells`) a non-walkable cell blocks sight. Pass [`LineOfSightMode.IgnoreUnwalkableCells`](LineOfSightMode.md) to see through obstacles that block movement but not vision (water, a pit, a glass wall):
+
+```csharp
+// Terrain doesn't block the shot, but units (occupied cells) still might.
+var visible = pathfinder.HasLineOfSight(shooter, target, LineOfSightMode.IgnoreUnwalkableCells);
+```
+
+The mode only governs walkability. Independently, an occupied cell blocks sight when `IsCalculatingOccupiedCells` is enabled — so "ignore terrain, but units still block" is expressible. The endpoints themselves are never tested, so a target standing on a blocked or occupied cell can still be "seen". Agent size is not considered — the check traces a single-cell ray. A cell always has line of sight to itself, and an out-of-range coordinate throws `ArgumentException`. 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,6 +17,7 @@ MPath uses a single codebase for both Unity and .NET:
 | [ReachableCell](ReachableCell.md) | A single reachable cell paired with its cheapest path cost |
 | [Cell](Cell.md) | Represents a single cell in the pathfinding grid |
 | [Coordinate](Coordinate.md) | Represents a position in the grid |
+| [LineOfSightMode](LineOfSightMode.md) | Controls whether unwalkable cells block `HasLineOfSight` |
 | [IAgent](IAgent.md) | Interface for entities that need pathfinding |
 | [ICellHolder](ICellHolder.md) | Interface for objects that hold cell data |
 | [IPathfinderSettings](IPathfinderSettings.md) | Interface for configuring pathfinding behavior |

--- a/docs/guides/distance-and-line-of-sight.md
+++ b/docs/guides/distance-and-line-of-sight.md
@@ -1,0 +1,67 @@
+# Distance and Line of Sight
+
+## Overview
+
+Not every spatial question needs a full path. MPath exposes three lightweight queries on `Pathfinder` for the common "how far?" and "can I see it?" cases that show up in fog-of-war, ranged combat, AI target selection and movement-range UIs:
+
+- `Pathfinder.GetManhattanDistance(from, to)` — taxicab distance
+- `Pathfinder.GetChebyshevDistance(from, to)` — chessboard distance
+- `pathfinder.HasLineOfSight(from, to)` — unobstructed straight line test
+
+All three are allocation-free. The two distance methods are also `static` and pure, so you can call them without a `Pathfinder` instance.
+
+## Distance metrics
+
+The distance helpers operate purely on coordinates — they ignore walls, cell weights and movement settings, so they always return the *geometric* grid distance, not a traversal cost. Use `GetReachable` or `GetPath` when you need the real cost of moving across the grid.
+
+| Metric | Formula | Use it when |
+|--------|------------------------|-------------|
+| Manhattan | `\|dx\| + \|dy\|` | Movement is cardinal-only (no diagonals). Also the A* heuristic MPath uses internally. |
+| Chebyshev | `max(\|dx\|, \|dy\|)` | Diagonal moves cost the same as cardinal ones (8-directional grids). |
+
+```csharp
+var a = new Coordinate(1, 1);
+var b = new Coordinate(4, 5);
+
+int manhattan = Pathfinder.GetManhattanDistance(a, b); // 3 + 4 = 7
+int chebyshev = Pathfinder.GetChebyshevDistance(a, b); // max(3, 4) = 4
+```
+
+Both metrics are symmetric (`distance(a, b) == distance(b, a)`), return `0` for identical coordinates, and return an `int` because grid coordinates are integers. `Chebyshev <= Manhattan` always holds.
+
+## Line of sight
+
+`HasLineOfSight` traces a [Bresenham line](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm) between the two cells and returns `false` as soon as it crosses a blocked cell — the same line-tracing the string-pulling path smoother uses internally. It is an O(distance) walk that allocates nothing.
+
+```csharp
+using var pathfinder = new Pathfinder(cells, width, height);
+
+if (pathfinder.HasLineOfSight(shooter, target))
+{
+    // Fire away — nothing is in the way.
+}
+else
+{
+    // Need to path around cover.
+    using var path = pathfinder.GetPath(agent, shooter, target);
+}
+```
+
+### What blocks sight
+
+A cell between the endpoints blocks line of sight when it is **not walkable**, or — when `IsCalculatingOccupiedCells` is enabled (the default) — when it is **occupied**. This mirrors how `GetPath` and `GetReachable` treat the grid, so "can I see it?" and "can I walk there?" stay consistent.
+
+### Behavior and edge cases
+
+- **Endpoints are never tested.** Only the cells *between* `from` and `to` are checked, so a target standing on a blocked or occupied cell (for example, an enemy unit) can still be seen.
+- **Single-cell ray.** Agent `Size` is not considered — the line is one cell wide. A large agent that *fits through* a gap visually may still be unable to *path* through it.
+- **Self.** A coordinate always has line of sight to itself.
+- **Bounds.** `from` and `to` must be inside the grid; an out-of-range coordinate throws `ArgumentException`.
+- **Symmetry.** `HasLineOfSight(a, b)` equals `HasLineOfSight(b, a)`.
+
+## When to use which
+
+- Need a quick range check or to sort candidates by closeness? Use a **distance metric**.
+- Need to know whether something is *visible* (no walls in between)? Use **`HasLineOfSight`**.
+- Need the actual route, accounting for walls and weights? Use [`GetPath`](../api/Pathfinder.md).
+- Need every tile within a movement budget? Use [`GetReachable`](movement-range.md).

--- a/docs/guides/distance-and-line-of-sight.md
+++ b/docs/guides/distance-and-line-of-sight.md
@@ -51,6 +51,25 @@ else
 
 A cell between the endpoints blocks line of sight when it is **not walkable**, or — when `IsCalculatingOccupiedCells` is enabled (the default) — when it is **occupied**. This mirrors how `GetPath` and `GetReachable` treat the grid, so "can I see it?" and "can I walk there?" stay consistent.
 
+### Seeing through obstacles (`LineOfSightMode`)
+
+Some obstacles block movement but not vision — water, a pit, a chasm, a glass wall. Because MPath models terrain with a single `IsWalkable` flag, the optional [`LineOfSightMode`](../api/LineOfSightMode.md) parameter lets you choose whether unwalkable cells block sight:
+
+```csharp
+// Default: walls block the line.
+bool blockedByWalls = pathfinder.HasLineOfSight(shooter, target);
+
+// See through unwalkable terrain (but occupants can still block).
+bool ignoringTerrain = pathfinder.HasLineOfSight(shooter, target, LineOfSightMode.IgnoreUnwalkableCells);
+```
+
+| Mode | Unwalkable cells | Occupied cells (when `IsCalculatingOccupiedCells`) |
+|------|------------------|----------------------------------------------------|
+| `BlockedByUnwalkableCells` *(default)* | block sight | block sight |
+| `IgnoreUnwalkableCells` | transparent | block sight |
+
+The mode only governs walkability; occupancy stays under `IsCalculatingOccupiedCells`. That orthogonality lets you express "ignore terrain, but units still block the shot" by pairing `IgnoreUnwalkableCells` with occupancy enabled.
+
 ### Behavior and edge cases
 
 - **Endpoints are never tested.** Only the cells *between* `from` and `to` are checked, so a target standing on a blocked or occupied cell (for example, an enemy unit) can still be seen.

--- a/src/mpath-source/Migs.MPath.Tests/PathfinderGeometryTests.cs
+++ b/src/mpath-source/Migs.MPath.Tests/PathfinderGeometryTests.cs
@@ -1,0 +1,234 @@
+using System;
+using FluentAssertions;
+using Migs.MPath.Core;
+using Migs.MPath.Core.Data;
+
+namespace Migs.MPath.Tests
+{
+    [TestFixture]
+    public class PathfinderGeometryTests
+    {
+        private const int GridSize = 10;
+
+        // ---------------------------------------------------------------------
+        // Manhattan distance
+        // ---------------------------------------------------------------------
+
+        [Test]
+        public void GetManhattanDistance_ReturnsSumOfAxisDeltas()
+        {
+            Pathfinder.GetManhattanDistance(new Coordinate(0, 0), new Coordinate(3, 4)).Should().Be(7);
+            Pathfinder.GetManhattanDistance(new Coordinate(2, 1), new Coordinate(5, 1)).Should().Be(3);
+            Pathfinder.GetManhattanDistance(new Coordinate(1, 5), new Coordinate(1, 0)).Should().Be(5);
+        }
+
+        [Test]
+        public void GetManhattanDistance_IsZeroForSameCoordinate()
+        {
+            Pathfinder.GetManhattanDistance(new Coordinate(4, 7), new Coordinate(4, 7)).Should().Be(0);
+        }
+
+        [Test]
+        public void GetManhattanDistance_IsSymmetric()
+        {
+            var a = new Coordinate(2, 8);
+            var b = new Coordinate(7, 3);
+
+            Pathfinder.GetManhattanDistance(a, b)
+                .Should().Be(Pathfinder.GetManhattanDistance(b, a));
+        }
+
+        // ---------------------------------------------------------------------
+        // Chebyshev distance
+        // ---------------------------------------------------------------------
+
+        [Test]
+        public void GetChebyshevDistance_ReturnsLargerAxisDelta()
+        {
+            Pathfinder.GetChebyshevDistance(new Coordinate(0, 0), new Coordinate(3, 4)).Should().Be(4);
+            Pathfinder.GetChebyshevDistance(new Coordinate(2, 1), new Coordinate(5, 1)).Should().Be(3);
+            Pathfinder.GetChebyshevDistance(new Coordinate(0, 0), new Coordinate(3, 3)).Should().Be(3);
+        }
+
+        [Test]
+        public void GetChebyshevDistance_IsZeroForSameCoordinate()
+        {
+            Pathfinder.GetChebyshevDistance(new Coordinate(4, 7), new Coordinate(4, 7)).Should().Be(0);
+        }
+
+        [Test]
+        public void GetChebyshevDistance_NeverExceedsManhattanDistance()
+        {
+            var a = new Coordinate(1, 2);
+            var b = new Coordinate(8, 6);
+
+            var chebyshev = Pathfinder.GetChebyshevDistance(a, b);
+            var manhattan = Pathfinder.GetManhattanDistance(a, b);
+
+            chebyshev.Should().BeLessThanOrEqualTo(manhattan);
+            chebyshev.Should().Be(7); // max(7, 4)
+        }
+
+        // ---------------------------------------------------------------------
+        // Line of sight
+        // ---------------------------------------------------------------------
+
+        [Test]
+        public void HasLineOfSight_OnEmptyGrid_ReturnsTrueForStraightLine()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(9, 0)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_OnEmptyGrid_ReturnsTrueForDiagonalLine()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(9, 9)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_ToSelf_ReturnsTrue()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(3, 3), new Coordinate(3, 3)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithWallOnTheLine_ReturnsFalse()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 2, 0, false); // directly between (0,0) and (4,0)
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0)).Should().BeFalse();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithWallBesideTheLine_ReturnsTrue()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 2, 1, false); // off the (0,0)->(4,0) horizontal line
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_DoesNotTestEndpoints()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            // Block both endpoints but leave the cells between them clear.
+            SetWalkable(cells, 0, 0, false);
+            SetWalkable(cells, 4, 0, false);
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithOccupiedCell_RespectsOccupancySetting()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetOccupied(cells, 2, 0, true); // occupied but still walkable, on the line
+
+            // Default settings calculate occupied cells, so the occupant blocks sight.
+            using (var blocking = new Pathfinder(cells, GridSize, GridSize))
+            {
+                blocking.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0)).Should().BeFalse();
+            }
+
+            // Disabling occupancy lets sight pass through the occupant.
+            var settings = new PathfinderSettings { IsCalculatingOccupiedCells = false };
+            using var ignoring = new Pathfinder(cells, GridSize, GridSize, settings);
+            ignoring.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_IsSymmetric()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 5, 5, false);
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            var forward = pathfinder.HasLineOfSight(new Coordinate(2, 2), new Coordinate(8, 8));
+            var backward = pathfinder.HasLineOfSight(new Coordinate(8, 8), new Coordinate(2, 2));
+
+            forward.Should().Be(backward);
+            forward.Should().BeFalse();
+        }
+
+        [Test]
+        public void HasLineOfSight_CanBeCalledRepeatedlyOnSameInstance()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(9, 9)).Should().BeTrue();
+            pathfinder.HasLineOfSight(new Coordinate(0, 9), new Coordinate(9, 0)).Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithInvalidOrigin_ThrowsArgumentException()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            var action = () => pathfinder.HasLineOfSight(new Coordinate(-1, 0), new Coordinate(5, 5));
+
+            action.Should().Throw<ArgumentException>().WithParameterName("from");
+        }
+
+        [Test]
+        public void HasLineOfSight_WithInvalidTarget_ThrowsArgumentException()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            var action = () => pathfinder.HasLineOfSight(new Coordinate(5, 5), new Coordinate(GridSize, GridSize));
+
+            action.Should().Throw<ArgumentException>().WithParameterName("to");
+        }
+
+        private static void SetWalkable(Cell[] cells, int x, int y, bool walkable)
+        {
+            cells[x * GridSize + y].IsWalkable = walkable;
+        }
+
+        private static void SetOccupied(Cell[] cells, int x, int y, bool occupied)
+        {
+            cells[x * GridSize + y].IsOccupied = occupied;
+        }
+
+        private static Cell[] CreateEmptyGrid(int width, int height)
+        {
+            var cells = new Cell[width * height];
+            for (var x = 0; x < width; x++)
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    var index = x * height + y;
+                    cells[index] = new Cell
+                    {
+                        Coordinate = new Coordinate(x, y),
+                        IsWalkable = true,
+                        IsOccupied = false,
+                        Weight = 1.0f
+                    };
+                }
+            }
+
+            return cells;
+        }
+    }
+}

--- a/src/mpath-source/Migs.MPath.Tests/PathfinderGeometryTests.cs
+++ b/src/mpath-source/Migs.MPath.Tests/PathfinderGeometryTests.cs
@@ -154,6 +154,66 @@ namespace Migs.MPath.Tests
         }
 
         [Test]
+        public void HasLineOfSight_WithIgnoreUnwalkableMode_SeesThroughWalls()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 2, 0, false); // wall directly on the (0,0)->(4,0) line
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            // Default mode is blocked by the wall...
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0))
+                      .Should().BeFalse();
+
+            // ...but IgnoreUnwalkableCells treats the wall as transparent.
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0),
+                          LineOfSightMode.IgnoreUnwalkableCells)
+                      .Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithIgnoreUnwalkableMode_StillBlockedByOccupiedCell()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetOccupied(cells, 2, 0, true); // occupant on the line; occupancy is on by default
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            // Ignoring unwalkable cells does NOT ignore occupants - units still block sight.
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0),
+                          LineOfSightMode.IgnoreUnwalkableCells)
+                      .Should().BeFalse();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithIgnoreUnwalkableMode_AndOccupancyDisabled_SeesThroughEverything()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 2, 0, false);  // wall on the line
+            SetOccupied(cells, 3, 0, true);   // occupant on the line
+
+            var settings = new PathfinderSettings { IsCalculatingOccupiedCells = false };
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize, settings);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0),
+                          LineOfSightMode.IgnoreUnwalkableCells)
+                      .Should().BeTrue();
+        }
+
+        [Test]
+        public void HasLineOfSight_WithExplicitBlockedMode_MatchesDefault()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            SetWalkable(cells, 2, 0, false);
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize);
+
+            pathfinder.HasLineOfSight(new Coordinate(0, 0), new Coordinate(4, 0),
+                          LineOfSightMode.BlockedByUnwalkableCells)
+                      .Should().BeFalse();
+        }
+
+        [Test]
         public void HasLineOfSight_IsSymmetric()
         {
             var cells = CreateEmptyGrid(GridSize, GridSize);

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/LineOfSightMode.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/LineOfSightMode.cs
@@ -1,0 +1,26 @@
+namespace Migs.MPath.Core.Data
+{
+    /// <summary>
+    /// Controls how <c>Pathfinder.HasLineOfSight</c> treats cells that are not walkable.
+    /// </summary>
+    /// <remarks>
+    /// This only governs the walkability of cells between the endpoints. Occupancy is handled separately:
+    /// when <c>IsCalculatingOccupiedCells</c> is enabled, an occupied cell blocks sight under either mode
+    /// (so "ignore terrain, but units still block" is expressible).
+    /// </remarks>
+    [System.Serializable]
+    public enum LineOfSightMode
+    {
+        /// <summary>
+        /// Cells that are not walkable block line of sight. This is the default and matches how walls
+        /// interrupt vision in most grid games.
+        /// </summary>
+        BlockedByUnwalkableCells = 0,
+
+        /// <summary>
+        /// Cells that are not walkable are treated as transparent and do not block line of sight.
+        /// Use this when an obstacle blocks movement but not vision (water, a pit, a chasm, a glass wall).
+        /// </summary>
+        IgnoreUnwalkableCells = 1
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/LineOfSightMode.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/LineOfSightMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: add9513fde604a0bad195345250e91bc

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs
@@ -39,23 +39,30 @@ namespace Migs.MPath.Core
 
         /// <summary>
         /// Determines whether there is an unobstructed straight line between two cells, i.e. whether every
-        /// cell the line passes through (excluding the two endpoints) is traversable. The line is traced
+        /// cell the line passes through (excluding the two endpoints) is transparent. The line is traced
         /// with a Bresenham walk, so this is an O(distance) query that allocates nothing.
-        /// A cell blocks line of sight when it is not walkable, or — when
-        /// <see cref="IPathfinderSettings.IsCalculatingOccupiedCells"/> is enabled — when it is occupied.
+        /// By default a cell blocks line of sight when it is not walkable; pass
+        /// <see cref="LineOfSightMode.IgnoreUnwalkableCells"/> to see through obstacles that block movement
+        /// but not vision. Independently of the mode, an occupied cell blocks sight when
+        /// <see cref="IPathfinderSettings.IsCalculatingOccupiedCells"/> is enabled.
         /// </summary>
         /// <remarks>
-        /// The endpoints themselves are never tested for walkability, so a target standing on an occupied
-        /// or blocked cell can still be "seen". Agent size is not considered — the check traces a single-cell
-        /// ray. A coordinate always has line of sight to itself.
+        /// The endpoints themselves are never tested, so a target standing on a blocked or occupied cell can
+        /// still be "seen". Agent size is not considered — the check traces a single-cell ray. A coordinate
+        /// always has line of sight to itself.
         /// </remarks>
         /// <param name="from">The observer coordinate. Must be inside the grid.</param>
         /// <param name="to">The target coordinate. Must be inside the grid.</param>
+        /// <param name="mode">
+        /// Whether cells that are not walkable block line of sight. Defaults to
+        /// <see cref="LineOfSightMode.BlockedByUnwalkableCells"/>.
+        /// </param>
         /// <returns><c>true</c> if no obstacle lies between the two coordinates; otherwise <c>false</c>.</returns>
         /// <exception cref="ArgumentException">
         /// Thrown when <paramref name="from"/> or <paramref name="to"/> is outside the valid field range.
         /// </exception>
-        public bool HasLineOfSight(Coordinate from, Coordinate to)
+        public bool HasLineOfSight(Coordinate from, Coordinate to,
+            LineOfSightMode mode = LineOfSightMode.BlockedByUnwalkableCells)
         {
             if (!IsPositionValid(from.X, from.Y))
             {
@@ -73,7 +80,7 @@ namespace Migs.MPath.Core
 
             fixed (Cell* ptr = &MemoryMarshal.GetReference(cells))
             {
-                return HasLineOfSight(from, to, ptr);
+                return HasLineOfSight(from, to, ptr, mode);
             }
         }
     }

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Migs.MPath.Core.Data;
+
+namespace Migs.MPath.Core
+{
+    public sealed unsafe partial class Pathfinder
+    {
+        /// <summary>
+        /// Calculates the Manhattan (taxicab) distance between two coordinates: the number of cardinal
+        /// (horizontal/vertical) steps separating them, <c>|dx| + |dy|</c>. This is the metric used by the
+        /// A* heuristic and matches the cost model when diagonal movement is disabled. It is a pure grid
+        /// measurement and ignores walls, weights and movement settings.
+        /// </summary>
+        /// <param name="from">The first coordinate.</param>
+        /// <param name="to">The second coordinate.</param>
+        /// <returns>The Manhattan distance between <paramref name="from"/> and <paramref name="to"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetManhattanDistance(Coordinate from, Coordinate to)
+        {
+            return Math.Abs(to.X - from.X) + Math.Abs(to.Y - from.Y);
+        }
+
+        /// <summary>
+        /// Calculates the Chebyshev (chessboard) distance between two coordinates: the number of steps
+        /// separating them when diagonal moves are allowed and cost the same as cardinal moves,
+        /// <c>max(|dx|, |dy|)</c>. It is a pure grid measurement and ignores walls, weights and movement
+        /// settings.
+        /// </summary>
+        /// <param name="from">The first coordinate.</param>
+        /// <param name="to">The second coordinate.</param>
+        /// <returns>The Chebyshev distance between <paramref name="from"/> and <paramref name="to"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetChebyshevDistance(Coordinate from, Coordinate to)
+        {
+            return Math.Max(Math.Abs(to.X - from.X), Math.Abs(to.Y - from.Y));
+        }
+
+        /// <summary>
+        /// Determines whether there is an unobstructed straight line between two cells, i.e. whether every
+        /// cell the line passes through (excluding the two endpoints) is traversable. The line is traced
+        /// with a Bresenham walk, so this is an O(distance) query that allocates nothing.
+        /// A cell blocks line of sight when it is not walkable, or — when
+        /// <see cref="IPathfinderSettings.IsCalculatingOccupiedCells"/> is enabled — when it is occupied.
+        /// </summary>
+        /// <remarks>
+        /// The endpoints themselves are never tested for walkability, so a target standing on an occupied
+        /// or blocked cell can still be "seen". Agent size is not considered — the check traces a single-cell
+        /// ray. A coordinate always has line of sight to itself.
+        /// </remarks>
+        /// <param name="from">The observer coordinate. Must be inside the grid.</param>
+        /// <param name="to">The target coordinate. Must be inside the grid.</param>
+        /// <returns><c>true</c> if no obstacle lies between the two coordinates; otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="from"/> or <paramref name="to"/> is outside the valid field range.
+        /// </exception>
+        public bool HasLineOfSight(Coordinate from, Coordinate to)
+        {
+            if (!IsPositionValid(from.X, from.Y))
+            {
+                throw new ArgumentException("Origin is outside the valid field range", nameof(from));
+            }
+
+            if (!IsPositionValid(to.X, to.Y))
+            {
+                throw new ArgumentException("Target is outside the valid field range", nameof(to));
+            }
+
+            InitializeCellsArray();
+
+            var cells = new Span<Cell>(_cells, 0, Size);
+
+            fixed (Cell* ptr = &MemoryMarshal.GetReference(cells))
+            {
+                return HasLineOfSight(from, to, ptr);
+            }
+        }
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Geometry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d32dc9eab81745a3ae989465c6a9164a

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_PathSmoothing.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_PathSmoothing.cs
@@ -42,7 +42,9 @@ namespace Migs.MPath.Core
                 // Find furthest point with line of sight from current
                 for (var i = originalLength - 1; i > currentIndex; i--)
                 {
-                    if (!HasLineOfSight(originalPath[currentIndex], originalPath[i], cells))
+                    // Smoothing may only shortcut across cells an agent can actually walk through.
+                    if (!HasLineOfSight(originalPath[currentIndex], originalPath[i], cells,
+                            LineOfSightMode.BlockedByUnwalkableCells))
                     {
                         continue;
                     }
@@ -100,7 +102,7 @@ namespace Migs.MPath.Core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool HasLineOfSight(Coordinate from, Coordinate to, Cell* cells)
+        private bool HasLineOfSight(Coordinate from, Coordinate to, Cell* cells, LineOfSightMode mode)
         {
             (int X, int Y) p0 = new Coordinate(from.X, from.Y);
             (int X, int Y) p1 = new Coordinate(to.X, to.Y);
@@ -137,8 +139,7 @@ namespace Migs.MPath.Core
                 // Skip checking the endpoints
                 if (currentCoord != from && currentCoord != to)
                 {
-                    var cell = GetWalkableLocation(cells, checkX, checkY);
-                    if (cell == null)
+                    if (IsLineOfSightBlocked(cells, checkX, checkY, mode))
                     {
                         // Hit an obstacle
                         return false;
@@ -157,6 +158,25 @@ namespace Migs.MPath.Core
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether the cell at (<paramref name="x"/>, <paramref name="y"/>) interrupts line of
+        /// sight. Under <see cref="LineOfSightMode.BlockedByUnwalkableCells"/> a non-walkable cell blocks;
+        /// under <see cref="LineOfSightMode.IgnoreUnwalkableCells"/> walkability is ignored. In both modes an
+        /// occupied cell blocks when <see cref="IPathfinderSettings.IsCalculatingOccupiedCells"/> is enabled.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsLineOfSightBlocked(Cell* cells, int x, int y, LineOfSightMode mode)
+        {
+            var cell = GetCell(cells, x, y);
+
+            if (mode == LineOfSightMode.BlockedByUnwalkableCells && !cell->IsWalkable)
+            {
+                return true;
+            }
+
+            return _settings.IsCalculatingOccupiedCells && cell->IsOccupied;
         }
     }
 }


### PR DESCRIPTION
## What

Adds three lightweight spatial queries to `Pathfinder`'s public API for range and visibility logic that doesn't require computing a full path:

| API | Kind | Description |
|-----|------|-------------|
| `static int GetManhattanDistance(Coordinate from, Coordinate to)` | pure | Taxicab distance `\|dx\| + \|dy\|` (the A* heuristic; cardinal-only grids). |
| `static int GetChebyshevDistance(Coordinate from, Coordinate to)` | pure | Chessboard distance `max(\|dx\|, \|dy\|)` (8-directional grids). |
| `bool HasLineOfSight(Coordinate from, Coordinate to, LineOfSightMode mode = BlockedByUnwalkableCells)` | instance | Whether an unobstructed straight line connects two cells. |

## Why

These are common needs in tactics/strategy and action games — range checks, AI target sorting, fog-of-war, ranged attacks, or short-circuiting pathfinding when a target is in plain sight — that previously required either a full `GetPath` call or rolling your own metric.

## Line-of-sight modes

`HasLineOfSight` takes an optional [`LineOfSightMode`](https://github.com/migus88/MPath/blob/feature/distance-line-of-sight-api/docs/api/LineOfSightMode.md) so callers can decide whether obstacles that block **movement** also block **vision** (MPath models terrain with a single `IsWalkable` flag):

| Mode | Unwalkable cells | Occupied cells (when `IsCalculatingOccupiedCells`) |
|------|------------------|----------------------------------------------------|
| `BlockedByUnwalkableCells` *(default)* | block sight | block sight |
| `IgnoreUnwalkableCells` | transparent (water, pits, glass walls) | block sight |

The mode governs walkability only — occupancy stays orthogonal, so "ignore terrain, but units still block the shot" is expressible.

## Implementation notes

- New `Pathfinder_Geometry.cs` partial + `LineOfSightMode` enum under the shared `src/mpath-unity-project/Packages/MPath/Source/` folder, so both the NuGet (`Migs.MPath`) and Unity (`com.migsweb.mpath`) packages pick them up. Kept engine-agnostic (`Source/` has no `UnityEngine` references).
- Distance metrics are `static`, pure, allocation-free integer functions — they ignore walls, weights and settings and return the geometric grid distance, not a traversal cost.
- `HasLineOfSight` reuses the existing Bresenham line-tracing already used by string-pulling smoothing, now sharing a single mode-aware `IsLineOfSightBlocked` per-cell test (smoothing always passes `BlockedByUnwalkableCells`, so paths still can't be shortcut through walls). Endpoints are never tested, the ray is single-cell (agent size ignored), a cell always sees itself, and an out-of-range coordinate throws `ArgumentException`.
- No new settings, so nothing to thread through `IPathfinderSettings`/`FastPathfinderSettings`.

## Verification

- `dotnet build src/mpath-source/Migs.MPath.sln` — succeeds (0 errors; only pre-existing warnings).
- `dotnet test src/mpath-source/Migs.MPath.Tests/Migs.MPath.Tests.csproj` — **100 passed, 0 failed**, including 21 cases in `PathfinderGeometryTests` (distance correctness/symmetry/zero; LOS clear/diagonal/self, wall on vs. beside the line, endpoint exclusion, occupancy-setting behavior, the two modes incl. "ignore terrain but units still block", symmetry, repeated calls, invalid-coordinate validation).

## Docs

- `docs/api/Pathfinder.md` — methods table + a "Distance and line of sight" section.
- `docs/api/LineOfSightMode.md` — new enum page (added to the API index).
- `docs/guides/distance-and-line-of-sight.md` — new guide (added to `docs/README.md` index).
- `README.md` — feature bullet + quick-start snippet.
- `CLAUDE.md` — architecture note for the new partial and enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)