### PR TITLE
Add stepwise A* search for visualizing pathfinding progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Releases are driven by interactive bash scripts in `ci/` (macOS-oriented; uses B
 
 ## Architecture
 
-### Core algorithm — `Source/Pathfinder.cs` (+ `Pathfinder_PathSmoothing.cs`, `Pathfinder_Reachability.cs`, `Pathfinder_Geometry.cs`)
+### Core algorithm — `Source/Pathfinder.cs` (+ `Pathfinder_PathSmoothing.cs`, `Pathfinder_Reachability.cs`, `Pathfinder_Geometry.cs`, `Pathfinder_Stepwise.cs`)
 
 `Pathfinder` is a `sealed unsafe partial class`. The hot path operates on a flat `Cell[]` via a raw `Cell*` pointer (`fixed`/`stackalloc`), indexed as `x * Height + y` (see `GetCell`). Key performance design points to preserve when editing:
 
@@ -80,10 +80,15 @@ Releases are driven by interactive bash scripts in `ci/` (macOS-oriented; uses B
 - **Four constructors → `InitializationMode`** (`CellsArray`, `CellHoldersArray`, `CellsMatrix`, `CellHoldersMatrix`). `InitializeCellsArray()` dispatches to the matching `TryInitializing...` method to flatten the caller's representation into `_cells` before each search. The `Cell[]`-array mode sorts in place (`Utils.CellsComparison`) and is the only mode that does **not** pool/copy. `CellsComparison` sorts **X-major then Y-minor** so the sorted layout matches `GetCell`'s `x * Height + y` indexing (the matrix/holder modes write cells at `Coordinate.X * Height + Coordinate.Y`); keep all four modes consistent or neighbor adjacency silently transposes.
 - **`stackalloc Cell*[8]` neighbors**, populated cardinal-first then diagonal. Diagonal inclusion respects `IsDiagonalMovementEnabled` and `IsMovementBetweenCornersEnabled` (corner-cutting). Agent `Size > 1` triggers a clearance scan in `GetWalkableLocation`.
 - Heuristic is **Manhattan distance** (`GetH`). G-score folds in per-cell `Weight` (when `IsCellWeightEnabled`) and straight-vs-diagonal travel multipliers.
+- **One A* iteration = `ExpandNext`** (dequeue → goal check → close + `PopulateNeighbors`/`ProcessNeighbors`). `CalculatePath`'s main loop and the stepwise search both call it, so the two share the exact same expansion logic (and find the same path). It is `AggressiveInlining` to keep the batch hot path unchanged — preserve that if you touch it.
 
 ### Geometry helpers — `Source/Pathfinder_Geometry.cs`
 
 Public spatial queries that don't produce a path: `static GetManhattanDistance`/`GetChebyshevDistance` (pure integer metrics over `Coordinate`, no grid state) and the instance `HasLineOfSight(from, to, LineOfSightMode mode = BlockedByUnwalkableCells)`. LOS pins `_cells` and delegates to the private Bresenham `HasLineOfSight(from, to, Cell*, mode)` in `Pathfinder_PathSmoothing.cs` (also used by string-pulling smoothing, which always passes `BlockedByUnwalkableCells`). The per-cell test is `IsLineOfSightBlocked`: under `BlockedByUnwalkableCells` a non-walkable cell blocks; under `IgnoreUnwalkableCells` it's transparent (see-through terrain). In **both** modes an occupied cell blocks when `IsCalculatingOccupiedCells` is set — the mode governs walkability only, occupancy stays orthogonal. Endpoints are never tested; the ray is single-cell (agent size ignored). `LineOfSightMode` is a public enum in `Source/Data/`.
+
+### Stepwise search — `Source/Pathfinder_Stepwise.cs`
+
+An **educational/visualization** API that runs the same A* one expansion at a time. `Pathfinder.BeginStepwiseSearch(agent, from, to)` returns a `Pathfinder.StepwiseSearch` (a public nested `IDisposable` class) you advance with `Tick()`; each tick returns an immutable `SearchStep` snapshot of the accumulated searched area (open + closed cells, with A* scores) plus the path once it succeeds. Chosen over the user-suggested "subclass Pathfinder" because `Pathfinder` is `sealed` and the algorithm internals are `private` — a nested class reuses them all (`ExpandNext`, `_openSet`, `ResetCells`, `GetCell`, …) **without** duplicating logic or widening access modifiers. Key points: it **pins `_cells` via a `GCHandle`** for the whole search (the open set holds raw pointers across ticks that must stay valid), so the session **must be disposed** and the owning `Pathfinder` can't service other queries until then (a `_searchSessionActive` guard throws on a second concurrent session). Discovery is tracked incrementally via a `bool[] _seen` keyed by pointer offset; per-tick snapshot building is O(discovered) — deliberately not optimized, since this is not the hot path. The visualized `Path` is the **raw** parent-pointer path (no smoothing), matching `PathResult`'s origin-excluded convention.
 
 ### Open set — `Source/Internal/UnsafePriorityQueue.cs`
 
@@ -94,6 +99,7 @@ A custom binary-heap min-priority-queue over `Cell*`. Each `Cell` stores its own
 - `Cell` (struct): public fields (`Coordinate`, `IsWalkable`, `IsOccupied`, `Weight`) + `internal` algorithm scratch fields (`ScoreF/G/H`, `Depth`, `ParentCoordinate`, `QueueIndex`, `IsClosed`). `Reset()` clears only the scratch state.
 - `Coordinate` (struct), `PathResult` (`IDisposable`; `IsSuccess`, `Length`, `Get(int)` and a `Path` enumerable over the pooled array), `PathfinderSettings` (public, mutable, implements `IPathfinderSettings`), `PathSmoothingMethod` (enum: `None`, etc.).
 - `RangeResult` (`IDisposable`; result of `Pathfinder.GetReachable`, rents a `ReachableCell[]` from the pool — must be disposed) and `ReachableCell` (readonly struct: `Coordinate` + `Cost`). The reachability search is a budget-bounded uniform-cost (Dijkstra) flood fill in `Pathfinder_Reachability.cs`; per-step cost = straight/diagonal multiplier **+** cell `Weight` (added when weighting is enabled, matching the main A*'s additive `GetCellWeightMultiplier` term), independent of the A* heuristic. Weight must be added, not multiplied — `Cell.Weight` defaults to 0, so a multiplier would zero out every step cost and flood the whole board.
+- `SearchStep` (plain class, **not** pooled/disposable — it owns plain arrays so snapshots survive across ticks), `SearchNode` (readonly struct: `Coordinate` + `SearchNodeState` + `ScoreG/H/F`), `SearchState` (enum: `InProgress`/`Success`/`Failure`), `SearchNodeState` (enum: `Open`/`Closed`). These back the stepwise search (see above); they intentionally favour clarity over allocation since the stepwise API is not the hot path.
 
 ### Settings flow
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A high-performance A* implementation for 2D grid navigation, designed primarily 
 - Designed for 2D grid-based navigation in games
 - Movement-range queries (`GetReachable`) for "where can this unit move?" mechanics
 - Distance metrics (Manhattan, Chebyshev) and line-of-sight checks for range and visibility logic
+- Stepwise search (`BeginStepwiseSearch`) for visualizing how the algorithm explores the grid
 - First-class support for Unity with dedicated integration components
 - Fully usable in any standalone .NET application
 - Extensively tested with comprehensive unit tests
@@ -182,6 +183,27 @@ pathfinder.HasLineOfSight(shooter, target, LineOfSightMode.IgnoreUnwalkableCells
 
 See the [Distance and Line of Sight guide](docs/guides/distance-and-line-of-sight.md) for details.
 
+### Visualizing the search
+
+Want to *show* how A* explores the grid (for teaching or a demo)? `BeginStepwiseSearch` runs the same search as `GetPath`, but one cell at a time, exposing the frontier and explored area after every step:
+
+```csharp
+using var search = pathfinder.BeginStepwiseSearch(agent, new Coordinate(1, 1), new Coordinate(8, 8));
+
+while (!search.IsComplete)
+{
+    var step = search.Tick();
+    Render(step.Searched); // open (frontier) vs closed (expanded) cells, with A* scores
+}
+
+if (search.Tick().State == SearchState.Success)
+{
+    DrawPath(search.Tick().Path);
+}
+```
+
+This is an educational/visualization tool — `GetPath` remains the way to compute paths in production. See the [Visualizing the Search guide](docs/guides/visualizing-search.md) for details.
+
 ### Documentation
 
 MPath comes with comprehensive documentation:
@@ -194,7 +216,7 @@ The API reference provides detailed information about all public classes, interf
 
 ### Important Notes
 
-- Always dispose `PathResult` and `RangeResult` objects after use (use `using` statements)
+- Always dispose `PathResult`, `RangeResult`, and `StepwiseSearch` objects after use (use `using` statements)
 - Reuse the pathfinder instance for best performance
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ MPath provides a robust implementation of the A* pathfinding algorithm with seve
 - [Pathfinder Settings](guides/pathfinder-settings.md) - Customizing pathfinding behavior
 - [Movement Range](guides/movement-range.md) - Finding every cell an agent can reach within a budget
 - [Distance and Line of Sight](guides/distance-and-line-of-sight.md) - Grid distance metrics and visibility checks
+- [Visualizing the Search](guides/visualizing-search.md) - Stepping through A* one expansion at a time
 - [Unity Integration](guides/unity-example.md) - Detailed guide for Unity projects
 - [Performance Considerations](guides/performance.md) - Optimizing for different scenarios
 - [API Reference](api/README.md) - Detailed API documentation

--- a/docs/api/Pathfinder.md
+++ b/docs/api/Pathfinder.md
@@ -19,6 +19,7 @@ A high-performance A* pathfinding implementation for grid-based environments.
 |--------|-------------|
 | `PathResult GetPath(IAgent agent, Coordinate from, Coordinate to)` | Calculates a path from starting position to destination. |
 | `RangeResult GetReachable(IAgent agent, Coordinate from, float budget)` | Finds every cell whose cheapest path cost from the origin is within the budget. |
+| `StepwiseSearch BeginStepwiseSearch(IAgent agent, Coordinate from, Coordinate to)` | Begins a tick-by-tick A* search for visualizing the algorithm's progress. |
 | `bool HasLineOfSight(Coordinate from, Coordinate to, LineOfSightMode mode = BlockedByUnwalkableCells)` | Returns whether an unobstructed straight line connects two cells. |
 | `static int GetManhattanDistance(Coordinate from, Coordinate to)` | Manhattan (taxicab) distance `\|dx\| + \|dy\|`. |
 | `static int GetChebyshevDistance(Coordinate from, Coordinate to)` | Chebyshev (chessboard) distance `max(\|dx\|, \|dy\|)`. |
@@ -77,6 +78,33 @@ foreach (var cell in range.Cells)
 ```
 
 See [RangeResult](RangeResult.md) and [ReachableCell](ReachableCell.md) for the returned types. Like `PathResult`, a `RangeResult` must be disposed (use `using`).
+
+### Visualizing the search (stepwise)
+
+`BeginStepwiseSearch` returns a [`StepwiseSearch`](StepwiseSearch.md) that runs the **same** A* expansion as `GetPath`, but one cell at a time, so you can display how the algorithm explores the grid. It is an **educational / visualization** facility — `GetPath` remains the way to compute a path in production.
+
+Each `Tick()` expands a single cell and returns a [`SearchStep`](SearchStep.md) snapshot containing the accumulated searched area (every discovered cell, tagged [`Open`](SearchNode.md) or `Closed`, with its A* scores) and — once the destination is reached — the resulting path.
+
+```csharp
+using var pathfinder = new Pathfinder(cells, 10, 10);
+var agent = new SimpleAgent { Size = 1 };
+
+using var search = pathfinder.BeginStepwiseSearch(agent, new Coordinate(1, 1), new Coordinate(8, 8));
+
+while (!search.IsComplete)
+{
+    var step = search.Tick();
+    Render(step.Searched);          // highlight open (frontier) vs closed (expanded) cells
+}
+
+var result = search.Tick();         // idempotent once complete
+if (result.State == SearchState.Success)
+{
+    DrawPath(result.Path);          // raw A* path (origin excluded, like PathResult)
+}
+```
+
+The session **pins** the pathfinder's cell buffer for the lifetime of the search, so it must be disposed (use `using`), and the owning `Pathfinder` must not be used for any other query until then. See the [Visualizing the search](../guides/visualizing-search.md) guide for a full walk-through.
 
 ### Distance and line of sight
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,6 +15,10 @@ MPath uses a single codebase for both Unity and .NET:
 | [PathResult](PathResult.md) | Contains the results of pathfinding operations |
 | [RangeResult](RangeResult.md) | Contains the results of a movement-range (reachability) query |
 | [ReachableCell](ReachableCell.md) | A single reachable cell paired with its cheapest path cost |
+| [StepwiseSearch](StepwiseSearch.md) | A tick-by-tick driver over the A* search for visualizing its progress |
+| [SearchStep](SearchStep.md) | A per-tick snapshot of a stepwise search (searched area + path) |
+| [SearchNode](SearchNode.md) | A single searched cell with its open/closed state and A* scores |
+| [SearchState](SearchState.md) | The overall state of a stepwise search (in progress / success / failure) |
 | [Cell](Cell.md) | Represents a single cell in the pathfinding grid |
 | [Coordinate](Coordinate.md) | Represents a position in the grid |
 | [LineOfSightMode](LineOfSightMode.md) | Controls whether unwalkable cells block `HasLineOfSight` |

--- a/docs/api/SearchNode.md
+++ b/docs/api/SearchNode.md
@@ -1,0 +1,40 @@
+# SearchNode Struct
+
+**Namespace:** `Migs.MPath.Core.Data`
+
+A readonly value type capturing a single cell that has been touched by a stepwise A* search, together with the A* scores the algorithm currently associates with it. Returned in batches as part of a [`SearchStep`](SearchStep.md) so the progress of the search can be displayed.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Coordinate` | `Coordinate` | The coordinate of the cell. |
+| `State` | `SearchNodeState` | Whether the cell is on the `Open` frontier or has been expanded into the `Closed` set. |
+| `ScoreG` | `float` | The cost of the cheapest path discovered so far from the origin (A* `g`). |
+| `ScoreH` | `float` | The heuristic estimate to the destination (A* `h`, Manhattan distance). |
+| `ScoreF` | `float` | The priority by which the open set is ordered: `g + h` (A* `f`). |
+
+## Constructors
+
+| Constructor | Description |
+|-------------|-------------|
+| `SearchNode(Coordinate coordinate, SearchNodeState state, float scoreG, float scoreH, float scoreF)` | Initializes a new searched-cell snapshot. |
+
+## SearchNodeState enum
+
+The role a node currently plays in the search — the distinction most useful when visualizing the algorithm:
+
+| Value | Description |
+|-------|-------------|
+| `Open` | The cell has been discovered and sits on the frontier (the open set), waiting to be expanded. |
+| `Closed` | The cell has already been expanded; its cheapest cost from the origin is final. |
+
+## Remarks
+
+- This is a `readonly struct`; enumerate it via [`SearchStep.Searched`](SearchStep.md).
+- Visualizers typically colour `Open` and `Closed` cells differently and may label each with its `ScoreG`/`ScoreF` to show how A* prioritizes the frontier.
+
+## See also
+
+- [SearchStep](SearchStep.md) — the snapshot that carries these nodes
+- [StepwiseSearch](StepwiseSearch.md) — the driver

--- a/docs/api/SearchState.md
+++ b/docs/api/SearchState.md
@@ -1,0 +1,18 @@
+# SearchState Enum
+
+**Namespace:** `Migs.MPath.Core.Data`
+
+Describes the overall state of a stepwise (tick-by-tick) A* search driven by [`Pathfinder.StepwiseSearch`](StepwiseSearch.md). Exposed on every [`SearchStep`](SearchStep.md).
+
+## Values
+
+| Value | Description |
+|-------|-------------|
+| `InProgress` | The search has not finished: the frontier still contains cells to expand and the destination has not been reached. Call `Tick()` again to advance it. |
+| `Success` | The destination has been reached. The final path is available on the returned `SearchStep`. |
+| `Failure` | The frontier was exhausted without reaching the destination: no path exists for this agent. |
+
+## See also
+
+- [StepwiseSearch](StepwiseSearch.md) — the driver
+- [SearchStep](SearchStep.md) — the per-tick snapshot that carries this state

--- a/docs/api/SearchStep.md
+++ b/docs/api/SearchStep.md
@@ -1,0 +1,30 @@
+# SearchStep Class
+
+**Namespace:** `Migs.MPath.Core.Data`
+
+An immutable snapshot of a stepwise A* search after a single [`StepwiseSearch.Tick`](StepwiseSearch.md). It carries the accumulated searched area (every cell discovered so far, open and closed) and — once the search succeeds — the resulting path, letting callers render the algorithm's progress frame by frame.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `State` | [`SearchState`](SearchState.md) | The overall state of the search after this tick. |
+| `IsComplete` | `bool` | `true` once the search has finished (succeeded or failed). |
+| `Iteration` | `int` | The 1-based index of the tick that produced this snapshot (cells expanded so far). |
+| `Current` | `Coordinate` | The cell expanded on this tick — the "head" of the search. On the final successful tick this is the destination. |
+| `Searched` | `IReadOnlyList<`[`SearchNode`](SearchNode.md)`>` | Every cell discovered so far, each tagged `Open` (frontier) or `Closed` (expanded), with its A* scores. |
+| `OpenCount` | `int` | The number of cells currently on the open frontier. |
+| `ClosedCount` | `int` | The number of cells currently in the closed (expanded) set. |
+| `Path` | `IReadOnlyList<Coordinate>` | The path once `State` is `Success`; otherwise empty. |
+
+## Remarks
+
+- Unlike [`PathResult`](PathResult.md) and [`RangeResult`](RangeResult.md), a `SearchStep` owns plain arrays rather than pooled buffers, so it does **not** need to be disposed and stays valid after the search advances. This trades a little allocation per tick for simplicity — the stepwise API is meant for visualization, not the allocation-free hot path.
+- `Path` follows the same convention as `PathResult`: the **origin cell is not included**, and the list ends at the destination. It is the raw A* path (parent-pointer chain); path smoothing is a separate post-process and is **not** applied here.
+- `OpenCount + ClosedCount == Searched.Count` always holds.
+
+## See also
+
+- [StepwiseSearch](StepwiseSearch.md) — the driver that produces these snapshots
+- [SearchNode](SearchNode.md) — an entry in `Searched`
+- [Visualizing the search](../guides/visualizing-search.md) — usage guide

--- a/docs/api/StepwiseSearch.md
+++ b/docs/api/StepwiseSearch.md
@@ -1,0 +1,52 @@
+# Pathfinder.StepwiseSearch Class
+
+**Namespace:** `Migs.MPath.Core` (nested in [`Pathfinder`](Pathfinder.md))
+
+A resumable, tick-by-tick driver over the A* search, intended for **visualizing or teaching** how the pathfinder explores the grid. Obtain one from [`Pathfinder.BeginStepwiseSearch`](Pathfinder.md). Each tick performs a single expansion using the owning `Pathfinder`'s own machinery — so it produces the same path as `GetPath` — and returns a [`SearchStep`](SearchStep.md) snapshot.
+
+Implements `IDisposable`.
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `State` | [`SearchState`](SearchState.md) | The overall state of the search (`InProgress`, `Success` or `Failure`). |
+| `IsComplete` | `bool` | `true` once the search has finished (succeeded or failed). |
+| `Iteration` | `int` | The number of expansions performed so far. |
+
+## Methods
+
+| Method | Description |
+|--------|-------------|
+| `SearchStep Tick()` | Expands a single cell and returns a snapshot of the search afterwards. Once complete, it is a no-op that returns the final snapshot again. |
+| `SearchStep RunToCompletion()` | Advances the search until it completes and returns the final snapshot. |
+| `void Dispose()` | Releases the pinned cell buffer and frees the owning `Pathfinder` for other queries. |
+
+## Remarks
+
+- **Disposal is required.** The session pins the pathfinder's cell buffer for the lifetime of the search (the open set holds raw pointers into it that must stay valid across ticks). Always wrap it in a `using` statement.
+- **One at a time.** While a session is active, the owning `Pathfinder` must not be used for any other query — including `GetPath`, `GetReachable`, or a second `BeginStepwiseSearch`. Starting a second session before disposing the first throws `InvalidOperationException`.
+- **Not a hot path.** Unlike `GetPath`, the stepwise API favours clarity over the allocation-free design — each `SearchStep` owns plain arrays. It is meant for visualization and teaching, not real-time movement.
+- `Tick()` after the search completes returns the same final `SearchStep` instance; `Tick()` after `Dispose()` throws `ObjectDisposedException`.
+
+## Example
+
+```csharp
+using var pathfinder = new Pathfinder(cells, 10, 10);
+var agent = new SimpleAgent { Size = 1 };
+
+using var search = pathfinder.BeginStepwiseSearch(agent, new Coordinate(0, 0), new Coordinate(9, 9));
+
+while (!search.IsComplete)
+{
+    var step = search.Tick();
+    Console.WriteLine($"tick {step.Iteration}: {step.OpenCount} open, {step.ClosedCount} closed");
+}
+```
+
+## See also
+
+- [SearchStep](SearchStep.md) — the per-tick snapshot
+- [SearchNode](SearchNode.md) — a single searched cell with its A* scores
+- [SearchState](SearchState.md) — the overall search state
+- [Visualizing the search](../guides/visualizing-search.md) — usage guide

--- a/docs/guides/visualizing-search.md
+++ b/docs/guides/visualizing-search.md
@@ -1,0 +1,76 @@
+# Visualizing the Search
+
+## Overview
+
+MPath normally computes a path in one shot with [`GetPath`](../api/Pathfinder.md). For teaching, debugging, or building an animated demo, it can also run the **same** A* search one expansion at a time, exposing the frontier and the explored area after every step. This is what [`Pathfinder.BeginStepwiseSearch`](../api/Pathfinder.md) provides.
+
+It is an **educational / visualization** facility, not a real-time movement API:
+
+- It runs the exact same expansion as `GetPath` (it shares the pathfinder's open set and cell buffer), so it finds the same path — it just pauses between expansions.
+- It favours clarity over the allocation-free hot path: each snapshot owns plain arrays you can keep and render.
+
+If you just want the path, keep using `GetPath`. Reach for the stepwise API when you want to *show how the path was found*.
+
+## The loop
+
+`BeginStepwiseSearch` returns a disposable [`StepwiseSearch`](../api/StepwiseSearch.md). Call `Tick()` to advance the search by one cell; each call returns a [`SearchStep`](../api/SearchStep.md) snapshot.
+
+```csharp
+using var pathfinder = new Pathfinder(cells, width, height);
+var agent = new SimpleAgent { Size = 1 };
+
+using var search = pathfinder.BeginStepwiseSearch(agent, new Coordinate(1, 1), new Coordinate(8, 8));
+
+while (!search.IsComplete)
+{
+    var step = search.Tick();
+
+    DrawFrontier(step.Searched);                 // open vs closed cells
+    Highlight(step.Current);                      // the cell expanded this tick
+    await NextFrame();
+}
+
+var final = search.Tick();                        // idempotent once complete
+if (final.State == SearchState.Success)
+{
+    DrawPath(final.Path);
+}
+```
+
+`RunToCompletion()` is a convenience that ticks until the search finishes and returns the final snapshot — handy when you only want the end state plus the full searched area:
+
+```csharp
+using var search = pathfinder.BeginStepwiseSearch(agent, from, to);
+var final = search.RunToCompletion();
+```
+
+## What a step contains
+
+Each [`SearchStep`](../api/SearchStep.md) is an immutable snapshot of the search so far:
+
+| Member | Meaning |
+|--------|---------|
+| `State` | `InProgress`, `Success`, or `Failure`. |
+| `Iteration` | How many cells have been expanded. |
+| `Current` | The cell expanded on this tick — the "head" of the search. |
+| `Searched` | Every cell discovered so far, each an [`Open`](../api/SearchNode.md) frontier cell or a `Closed` (expanded) cell, with its A* `g`/`h`/`f` scores. |
+| `OpenCount` / `ClosedCount` | Sizes of the frontier and the closed set (`OpenCount + ClosedCount == Searched.Count`). |
+| `Path` | The path once `State` is `Success`; otherwise empty. |
+
+The `Searched` list is the accumulated searched area — the cells you typically colour to show progress. The standard A* picture is to draw the `Closed` set in one colour (already explored), the `Open` frontier in another (queued to explore), `Current` as the cursor, and `Path` once the search succeeds. Each [`SearchNode`](../api/SearchNode.md) also carries its `ScoreG` (cost from the origin) and `ScoreF` (priority), which you can label to show *why* A* picks the cells it does.
+
+### The path
+
+`Path` is the **raw** A* path — the parent-pointer chain from the origin to the destination. Following the same convention as [`PathResult`](../api/PathResult.md), it **excludes the origin cell** and ends at the destination. Path smoothing (configured via `PathfinderSettings.PathSmoothingMethod`) is a separate post-process and is **not** applied to the visualized path, so what you see is the search's own result.
+
+## Lifetime and rules
+
+- **Dispose the session.** It pins the pathfinder's cell buffer for the duration of the search (the open set holds raw pointers into it that must stay valid across ticks). Always wrap it in `using`.
+- **One search at a time.** While a session is active, don't use the owning `Pathfinder` for anything else — not `GetPath`, not `GetReachable`, not a second `BeginStepwiseSearch`. Starting a second session before disposing the first throws `InvalidOperationException`. Once disposed, the pathfinder is free for normal use again.
+- `Tick()` after completion returns the same final snapshot; `Tick()` after `Dispose()` throws `ObjectDisposedException`.
+
+## Edge cases
+
+- **Origin equals destination** succeeds on the first tick with an empty `Path` (matching `GetPath`).
+- **Unreachable destination** ends in `State == Failure` with an empty `Path`; `Searched` then contains every cell the agent could reach (all `Closed`, `OpenCount == 0`).
+- An origin or destination outside the grid throws `ArgumentException`; a `null` agent throws `ArgumentNullException`.

--- a/src/mpath-source/Migs.MPath.Tests/PathfinderStepwiseTests.cs
+++ b/src/mpath-source/Migs.MPath.Tests/PathfinderStepwiseTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Migs.MPath.Core;
+using Migs.MPath.Core.Data;
+using Migs.MPath.Tests.Implementations;
+
+namespace Migs.MPath.Tests
+{
+    [TestFixture]
+    public class PathfinderStepwiseTests
+    {
+        private const int GridSize = 10;
+
+        [Test]
+        public void BeginStepwiseSearch_RunToCompletion_ProducesSamePathAsGetPath()
+        {
+            var from = new Coordinate(1, 1);
+            var to = new Coordinate(8, 6);
+            var agent = new Agent { Size = 1 };
+
+            // Default settings use no smoothing, so GetPath returns the raw A* path the stepwise search traces.
+            List<Coordinate> batchPath;
+            using (var batchPathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize))
+            using (var batchResult = batchPathfinder.GetPath(agent, from, to))
+            {
+                batchResult.IsSuccess.Should().BeTrue();
+                batchPath = batchResult.Path.ToList();
+            }
+
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(agent, from, to);
+
+            var final = search.RunToCompletion();
+
+            final.State.Should().Be(SearchState.Success);
+            final.IsComplete.Should().BeTrue();
+            final.Path.Should().Equal(batchPath);
+        }
+
+        [Test]
+        public void RunToCompletion_OnSuccess_PathReachesDestinationAndIsContiguous()
+        {
+            var from = new Coordinate(0, 0);
+            var to = new Coordinate(9, 9);
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 }, from, to);
+            var final = search.RunToCompletion();
+
+            final.State.Should().Be(SearchState.Success);
+
+            // Following the PathResult convention, the origin is excluded and the path ends at the destination.
+            final.Path.Should().NotBeEmpty();
+            final.Path.Last().Should().Be(to);
+            final.Path.Should().NotContain(from);
+
+            // Every consecutive pair must be adjacent (Chebyshev distance 1).
+            var steps = new[] { from }.Concat(final.Path).ToList();
+            for (var i = 1; i < steps.Count; i++)
+            {
+                Pathfinder.GetChebyshevDistance(steps[i - 1], steps[i]).Should().Be(1);
+            }
+        }
+
+        [Test]
+        public void Tick_AccumulatesSearchedAreaMonotonically()
+        {
+            var from = new Coordinate(5, 5);
+            var to = new Coordinate(9, 9);
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 }, from, to);
+
+            var previousSearched = 0;
+            SearchStep step;
+
+            do
+            {
+                step = search.Tick();
+
+                // The searched area never shrinks as the search advances.
+                step.Searched.Count.Should().BeGreaterThanOrEqualTo(previousSearched);
+                previousSearched = step.Searched.Count;
+
+                // Open + Closed always partitions the searched set.
+                (step.OpenCount + step.ClosedCount).Should().Be(step.Searched.Count);
+            }
+            while (!step.IsComplete);
+
+            step.State.Should().Be(SearchState.Success);
+            step.Searched.Count.Should().BeGreaterThan(1);
+        }
+
+        [Test]
+        public void Tick_WhileInProgress_ClosesExactlyOneCellPerExpansion()
+        {
+            var from = new Coordinate(0, 0);
+            var to = new Coordinate(9, 9);
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 }, from, to);
+
+            SearchStep step;
+            do
+            {
+                step = search.Tick();
+
+                if (step.State == SearchState.InProgress)
+                {
+                    // Each in-progress expansion closes exactly one (previously open) cell.
+                    step.ClosedCount.Should().Be(step.Iteration);
+
+                    // The most recently expanded cell is part of the searched area and marked closed.
+                    var currentNode = step.Searched.Single(n => n.Coordinate == step.Current);
+                    currentNode.State.Should().Be(SearchNodeState.Closed);
+                }
+            }
+            while (!step.IsComplete);
+        }
+
+        [Test]
+        public void Searched_ExposesAStarScoresForTheOrigin()
+        {
+            var from = new Coordinate(3, 4);
+            var to = new Coordinate(7, 7);
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 }, from, to);
+
+            var first = search.Tick();
+
+            var originNode = first.Searched.Single(n => n.Coordinate == from);
+            originNode.ScoreG.Should().Be(0f);
+            // f = g + h is the priority by which the open set is ordered.
+            originNode.ScoreF.Should().BeApproximately(originNode.ScoreG + originNode.ScoreH, 0.0001f);
+        }
+
+        [Test]
+        public void BeginStepwiseSearch_WithUnreachableDestination_ReportsFailure()
+        {
+            var cells = CreateEmptyGrid(GridSize, GridSize);
+            var settings = new PathfinderSettings { IsDiagonalMovementEnabled = false };
+
+            // Fence the destination (9,9) off from the rest of the grid.
+            SetWalkable(cells, 8, 9, false);
+            SetWalkable(cells, 9, 8, false);
+
+            using var pathfinder = new Pathfinder(cells, GridSize, GridSize, settings);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 },
+                new Coordinate(0, 0), new Coordinate(9, 9));
+
+            var final = search.RunToCompletion();
+
+            final.State.Should().Be(SearchState.Failure);
+            final.IsComplete.Should().BeTrue();
+            final.Path.Should().BeEmpty();
+
+            // A failed search exhausts the frontier: everything reachable ends up closed.
+            final.OpenCount.Should().Be(0);
+            final.ClosedCount.Should().Be(final.Searched.Count);
+            final.Searched.Should().NotContain(n => n.Coordinate == new Coordinate(9, 9));
+        }
+
+        [Test]
+        public void StepwiseSearch_WhenOriginEqualsDestination_SucceedsOnFirstTick()
+        {
+            var origin = new Coordinate(4, 4);
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 }, origin, origin);
+
+            var step = search.Tick();
+
+            step.State.Should().Be(SearchState.Success);
+            // Matching GetPath, an already-at-destination search yields an empty path.
+            step.Path.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Tick_AfterCompletion_IsIdempotent()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            using var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 },
+                new Coordinate(0, 0), new Coordinate(2, 2));
+
+            var final = search.RunToCompletion();
+            var iterationAtCompletion = final.Iteration;
+
+            var again = search.Tick();
+
+            again.Should().BeSameAs(final);
+            again.Iteration.Should().Be(iterationAtCompletion);
+        }
+
+        [Test]
+        public void BeginStepwiseSearch_WhileAnotherSearchIsActive_Throws()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            var agent = new Agent { Size = 1 };
+
+            var first = pathfinder.BeginStepwiseSearch(agent, new Coordinate(0, 0), new Coordinate(5, 5));
+
+            var startSecond = () => pathfinder.BeginStepwiseSearch(agent, new Coordinate(0, 0), new Coordinate(5, 5));
+            startSecond.Should().Throw<InvalidOperationException>();
+
+            // Disposing the first session frees the instance for a new search.
+            first.Dispose();
+            using var second = pathfinder.BeginStepwiseSearch(agent, new Coordinate(0, 0), new Coordinate(5, 5));
+            second.RunToCompletion().State.Should().Be(SearchState.Success);
+        }
+
+        [Test]
+        public void Pathfinder_CanRunGetPathAfterAStepwiseSearchIsDisposed()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            var agent = new Agent { Size = 1 };
+            var from = new Coordinate(0, 0);
+            var to = new Coordinate(7, 7);
+
+            using (var search = pathfinder.BeginStepwiseSearch(agent, from, to))
+            {
+                search.RunToCompletion().State.Should().Be(SearchState.Success);
+            }
+
+            // The pinned buffer is released on dispose, so the regular API works again.
+            using var result = pathfinder.GetPath(agent, from, to);
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Test]
+        public void Tick_AfterDisposal_ThrowsObjectDisposedException()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+            var search = pathfinder.BeginStepwiseSearch(new Agent { Size = 1 },
+                new Coordinate(0, 0), new Coordinate(5, 5));
+
+            search.Dispose();
+
+            var action = () => search.Tick();
+            action.Should().Throw<ObjectDisposedException>();
+        }
+
+        [Test]
+        public void BeginStepwiseSearch_WithNullAgent_ThrowsArgumentNullException()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+
+            var action = () => pathfinder.BeginStepwiseSearch(null!, new Coordinate(0, 0), new Coordinate(5, 5));
+
+            action.Should().Throw<ArgumentNullException>().WithParameterName("agent");
+        }
+
+        [Test]
+        public void BeginStepwiseSearch_WithInvalidOrigin_ThrowsArgumentException()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+
+            var action = () => pathfinder.BeginStepwiseSearch(new Agent { Size = 1 },
+                new Coordinate(GridSize + 3, 0), new Coordinate(5, 5));
+
+            action.Should().Throw<ArgumentException>().WithParameterName("from");
+        }
+
+        [Test]
+        public void BeginStepwiseSearch_WithInvalidDestination_ThrowsArgumentException()
+        {
+            using var pathfinder = new Pathfinder(CreateEmptyGrid(GridSize, GridSize), GridSize, GridSize);
+
+            var action = () => pathfinder.BeginStepwiseSearch(new Agent { Size = 1 },
+                new Coordinate(0, 0), new Coordinate(GridSize + 3, 0));
+
+            action.Should().Throw<ArgumentException>().WithParameterName("to");
+        }
+
+        [Test]
+        public void RunToCompletion_AroundAWall_FindsTheSamePathAsGetPath()
+        {
+            var from = new Coordinate(0, 5);
+            var to = new Coordinate(9, 5);
+            var agent = new Agent { Size = 1 };
+
+            static Cell[] BuildWalledGrid()
+            {
+                var cells = CreateEmptyGrid(GridSize, GridSize);
+                // Vertical wall down the middle with a single gap at the top.
+                for (var y = 1; y < GridSize; y++)
+                {
+                    SetWalkable(cells, 5, y, false);
+                }
+
+                return cells;
+            }
+
+            var settings = new PathfinderSettings { IsDiagonalMovementEnabled = false };
+
+            List<Coordinate> batchPath;
+            using (var batchPathfinder = new Pathfinder(BuildWalledGrid(), GridSize, GridSize, settings))
+            using (var batchResult = batchPathfinder.GetPath(agent, from, to))
+            {
+                batchResult.IsSuccess.Should().BeTrue();
+                batchPath = batchResult.Path.ToList();
+            }
+
+            using var pathfinder = new Pathfinder(BuildWalledGrid(), GridSize, GridSize, settings);
+            using var search = pathfinder.BeginStepwiseSearch(agent, from, to);
+            var final = search.RunToCompletion();
+
+            final.State.Should().Be(SearchState.Success);
+            final.Path.Should().Equal(batchPath);
+
+            // The wall cells must never appear in the searched area.
+            final.Searched.Should().NotContain(n => n.Coordinate.X == 5 && n.Coordinate.Y >= 1);
+        }
+
+        private static void SetWalkable(Cell[] cells, int x, int y, bool walkable)
+        {
+            cells[x * GridSize + y].IsWalkable = walkable;
+        }
+
+        private static Cell[] CreateEmptyGrid(int width, int height)
+        {
+            var cells = new Cell[width * height];
+            for (var x = 0; x < width; x++)
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    var index = x * height + y;
+                    cells[index] = new Cell
+                    {
+                        Coordinate = new Coordinate(x, y),
+                        IsWalkable = true,
+                        IsOccupied = false,
+                        Weight = 1.0f
+                    };
+                }
+            }
+
+            return cells;
+        }
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNode.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNode.cs
@@ -1,0 +1,58 @@
+namespace Migs.MPath.Core.Data
+{
+    /// <summary>
+    /// A snapshot of a single cell that has been touched by a stepwise A* search, together with the A*
+    /// scores the algorithm currently associates with it. Returned in batches as part of a
+    /// <see cref="SearchStep"/> so the progress of the search can be displayed.
+    /// </summary>
+    public readonly struct SearchNode
+    {
+        /// <summary>
+        /// Gets the coordinate of the cell.
+        /// </summary>
+        public Coordinate Coordinate { get; }
+
+        /// <summary>
+        /// Gets whether the cell is currently on the <see cref="SearchNodeState.Open"/> frontier or has
+        /// already been expanded into the <see cref="SearchNodeState.Closed"/> set.
+        /// </summary>
+        public SearchNodeState State { get; }
+
+        /// <summary>
+        /// Gets the cost of the cheapest path discovered so far from the origin to this cell (the A* <c>g</c> score).
+        /// </summary>
+        public float ScoreG { get; }
+
+        /// <summary>
+        /// Gets the heuristic estimate from this cell to the destination (the A* <c>h</c> score, Manhattan distance).
+        /// </summary>
+        public float ScoreH { get; }
+
+        /// <summary>
+        /// Gets the priority by which the cell is ordered in the open set: <c>g + h</c> (the A* <c>f</c> score).
+        /// </summary>
+        public float ScoreF { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchNode"/> struct.
+        /// </summary>
+        /// <param name="coordinate">The coordinate of the cell.</param>
+        /// <param name="state">Whether the cell is open (frontier) or closed (expanded).</param>
+        /// <param name="scoreG">The cheapest cost from the origin discovered so far.</param>
+        /// <param name="scoreH">The heuristic estimate to the destination.</param>
+        /// <param name="scoreF">The combined priority (<c>g + h</c>).</param>
+        public SearchNode(Coordinate coordinate, SearchNodeState state, float scoreG, float scoreH, float scoreF)
+        {
+            Coordinate = coordinate;
+            State = state;
+            ScoreG = scoreG;
+            ScoreH = scoreH;
+            ScoreF = scoreF;
+        }
+
+        public override string ToString()
+        {
+            return $"{Coordinate} [{State}] g={ScoreG} h={ScoreH} f={ScoreF}";
+        }
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNode.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e95a7ce838b04776b25c4fbeb33d59e8

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNodeState.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNodeState.cs
@@ -1,0 +1,20 @@
+namespace Migs.MPath.Core.Data
+{
+    /// <summary>
+    /// The role a <see cref="SearchNode"/> currently plays in a stepwise A* search. This is the distinction
+    /// most useful when visualizing the algorithm: the <see cref="Open"/> frontier versus the already
+    /// expanded <see cref="Closed"/> set.
+    /// </summary>
+    public enum SearchNodeState
+    {
+        /// <summary>
+        /// The cell has been discovered and sits on the frontier (the open set), waiting to be expanded.
+        /// </summary>
+        Open,
+
+        /// <summary>
+        /// The cell has already been expanded (the closed set); its cheapest cost from the origin is final.
+        /// </summary>
+        Closed
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNodeState.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchNodeState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 345d2bb47b5f4a7cbbcb68b67780c746

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchState.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchState.cs
@@ -1,0 +1,25 @@
+namespace Migs.MPath.Core.Data
+{
+    /// <summary>
+    /// Describes the overall state of a stepwise (tick-by-tick) A* search driven by
+    /// <see cref="Pathfinder.StepwiseSearch"/>.
+    /// </summary>
+    public enum SearchState
+    {
+        /// <summary>
+        /// The search has not finished yet: the frontier still contains cells to expand and the
+        /// destination has not been reached. Call <see cref="Pathfinder.StepwiseSearch.Tick"/> again to advance it.
+        /// </summary>
+        InProgress,
+
+        /// <summary>
+        /// The destination has been reached. The final path is available on the returned <see cref="SearchStep"/>.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// The frontier was exhausted without reaching the destination: no path exists for this agent.
+        /// </summary>
+        Failure
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchState.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 43a2eebca60d4925b4bf6d4863c31e99

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchStep.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchStep.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace Migs.MPath.Core.Data
+{
+    /// <summary>
+    /// An immutable snapshot of a stepwise A* search after a single <see cref="Pathfinder.StepwiseSearch.Tick"/>.
+    /// It carries the accumulated searched area (every cell discovered so far, open and closed) and, once the
+    /// search succeeds, the resulting path — letting callers render the algorithm's progress frame by frame.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="PathResult"/> and <see cref="RangeResult"/>, a <see cref="SearchStep"/> owns plain
+    /// arrays rather than pooled buffers, so it does not need to be disposed and stays valid after the search
+    /// advances. This trades a little allocation per tick for simplicity — the stepwise API is meant for
+    /// visualization and teaching, not the allocation-free hot path.
+    /// </remarks>
+    public sealed class SearchStep
+    {
+        /// <summary>
+        /// Gets the overall state of the search after this tick.
+        /// </summary>
+        public SearchState State { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the search has finished (succeeded or failed).
+        /// </summary>
+        public bool IsComplete => State != SearchState.InProgress;
+
+        /// <summary>
+        /// Gets the 1-based index of the tick that produced this snapshot (the number of cells expanded so far).
+        /// </summary>
+        public int Iteration { get; }
+
+        /// <summary>
+        /// Gets the coordinate of the cell expanded on this tick — the "head" of the search. On the final
+        /// successful tick this is the destination.
+        /// </summary>
+        public Coordinate Current { get; }
+
+        /// <summary>
+        /// Gets every cell discovered so far, each tagged as <see cref="SearchNodeState.Open"/> (frontier) or
+        /// <see cref="SearchNodeState.Closed"/> (expanded), with its current A* scores. This is the accumulated
+        /// searched area to highlight when visualizing the search.
+        /// </summary>
+        public IReadOnlyList<SearchNode> Searched { get; }
+
+        /// <summary>
+        /// Gets the number of cells currently on the open frontier.
+        /// </summary>
+        public int OpenCount { get; }
+
+        /// <summary>
+        /// Gets the number of cells currently in the closed (expanded) set.
+        /// </summary>
+        public int ClosedCount { get; }
+
+        /// <summary>
+        /// Gets the path from the origin to the destination once <see cref="State"/> is
+        /// <see cref="SearchState.Success"/>; otherwise an empty list. Following the same convention as
+        /// <see cref="PathResult"/>, the origin cell itself is not included. This is the raw A* path
+        /// (parent-pointer chain); path smoothing is a separate post-process and is not applied here.
+        /// </summary>
+        public IReadOnlyList<Coordinate> Path { get; }
+
+        internal SearchStep(SearchState state, int iteration, Coordinate current,
+            SearchNode[] searched, int openCount, int closedCount, Coordinate[] path)
+        {
+            State = state;
+            Iteration = iteration;
+            Current = current;
+            Searched = searched ?? Array.Empty<SearchNode>();
+            OpenCount = openCount;
+            ClosedCount = closedCount;
+            Path = path ?? Array.Empty<Coordinate>();
+        }
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Data/SearchStep.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Data/SearchStep.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5fb01307bb7d416ba7ac22df8ae77f0e

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder.cs
@@ -226,36 +226,58 @@ namespace Migs.MPath.Core
         private PathResult CalculatePath(IAgent agent, Coordinate from, Coordinate to, Cell* ptr)
         {
             var scoreH = GetH(from.X, from.Y, to.X, to.Y);
-            var current = GetCell(ptr, from.X, from.Y);
-            
-            _openSet.Enqueue(current, scoreH);
+            var start = GetCell(ptr, from.X, from.Y);
+
+            _openSet.Enqueue(start, scoreH);
 
             var neighbors = stackalloc Cell*[MaxNeighbors];
             var agentSize = agent.Size;
 
-            // A* algorithm main loop
+            // A* algorithm main loop. Each iteration expands one cell; ExpandNext is the single
+            // source of truth for that step, shared with the stepwise (tick-by-tick) search.
+            Cell* current = null;
             while (_openSet.Count > 0)
             {
-                current = _openSet.Dequeue();
-
-                if (current->Coordinate == to)
+                if (ExpandNext(ptr, to, agentSize, neighbors, out current))
                 {
+                    // Destination dequeued — search is done.
                     break;
                 }
-
-                current->IsClosed = true;
-
-                PopulateNeighbors(ptr, current, agentSize, neighbors);
-                ProcessNeighbors(current, neighbors, to);
             }
 
             // Path reconstruction
-            if (current->Coordinate != to)
+            if (current == null || current->Coordinate != to)
             {
                 return PathResult.Failure();
             }
 
             return ReconstructPath(current, ptr);
+        }
+
+        /// <summary>
+        /// Expands the next cell from the open set: dequeues the current best candidate and — unless it is the
+        /// destination — closes it and relaxes its neighbors. This is one iteration of the A* main loop,
+        /// factored out so the batch <see cref="GetPath"/> and the stepwise <see cref="StepwiseSearch"/> run the
+        /// exact same logic. The caller is responsible for ensuring the open set is non-empty.
+        /// </summary>
+        /// <returns><c>true</c> when the dequeued cell is the destination and the search should stop;
+        /// otherwise <c>false</c>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool ExpandNext(Cell* ptr, Coordinate to, int agentSize, Cell** neighbors, out Cell* current)
+        {
+            current = _openSet.Dequeue();
+
+            if (current->Coordinate == to)
+            {
+                return true;
+            }
+
+            current->IsClosed = true;
+
+            PopulateNeighbors(ptr, current, agentSize, neighbors);
+            ProcessNeighbors(current, neighbors, to);
+
+            return false;
         }
 
         /// <summary>

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Stepwise.cs
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Stepwise.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Migs.MPath.Core.Data;
+using Migs.MPath.Core.Interfaces;
+
+namespace Migs.MPath.Core
+{
+    public sealed unsafe partial class Pathfinder
+    {
+        // Guards against two concurrent stepwise searches sharing this instance's open set and cell buffer.
+        private bool _searchSessionActive;
+
+        /// <summary>
+        /// Begins a stepwise (tick-by-tick) A* search that can be advanced one expansion at a time, exposing
+        /// the accumulated searched area and — once it succeeds — the resulting path. This is an
+        /// <b>educational / visualization</b> facility for showing how the algorithm explores the grid; the
+        /// regular <see cref="GetPath"/> remains the way to compute a path in one shot.
+        /// </summary>
+        /// <remarks>
+        /// The returned <see cref="StepwiseSearch"/> drives the very same A* expansion as <see cref="GetPath"/>
+        /// (it shares this instance's open set and cell buffer), so it produces an identical path; it simply
+        /// pauses between expansions. Because it pins this instance's cell buffer for the lifetime of the
+        /// search, the session <b>must be disposed</b> (wrap it in <c>using</c>), and the owning
+        /// <see cref="Pathfinder"/> must not be used for any other query — including a second
+        /// <see cref="BeginStepwiseSearch"/> — until the session is disposed.
+        /// </remarks>
+        /// <param name="agent">The agent for which to search. Cannot be null.</param>
+        /// <param name="from">The origin coordinate. Must be inside the grid.</param>
+        /// <param name="to">The destination coordinate. Must be inside the grid.</param>
+        /// <returns>A disposable <see cref="StepwiseSearch"/> positioned before the first expansion.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="agent"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="from"/> or <paramref name="to"/> is outside the grid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when a stepwise search is already active on this instance.</exception>
+        public StepwiseSearch BeginStepwiseSearch(IAgent agent, Coordinate from, Coordinate to)
+        {
+            if (agent == null)
+            {
+                throw new ArgumentNullException(nameof(agent));
+            }
+
+            if (!IsPositionValid(from.X, from.Y))
+            {
+                throw new ArgumentException("Origin is outside the valid field range", nameof(from));
+            }
+
+            if (!IsPositionValid(to.X, to.Y))
+            {
+                throw new ArgumentException("Destination is outside the valid field range", nameof(to));
+            }
+
+            if (_searchSessionActive)
+            {
+                throw new InvalidOperationException(
+                    "A stepwise search is already in progress on this Pathfinder. " +
+                    "Dispose the previous StepwiseSearch before starting a new one.");
+            }
+
+            _searchSessionActive = true;
+
+            try
+            {
+                return new StepwiseSearch(this, agent, from, to);
+            }
+            catch
+            {
+                _searchSessionActive = false;
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// A resumable, tick-by-tick driver over the A* search, intended for visualizing or teaching how the
+        /// pathfinder explores the grid. Each <see cref="Tick"/> performs a single expansion using the owning
+        /// <see cref="Pathfinder"/>'s own machinery (so the result matches <see cref="GetPath"/>) and returns a
+        /// <see cref="SearchStep"/> with the accumulated searched area and, on success, the path.
+        /// </summary>
+        /// <remarks>
+        /// Obtain an instance from <see cref="BeginStepwiseSearch"/>. It pins the pathfinder's cell buffer for
+        /// the duration of the search and therefore implements <see cref="IDisposable"/> — always dispose it.
+        /// This type favours clarity over the allocation-free design of the main pathfinder: it is not meant
+        /// for a real-time hot path.
+        /// </remarks>
+        public sealed unsafe class StepwiseSearch : IDisposable
+        {
+            private readonly Pathfinder _pathfinder;
+            private readonly Coordinate _to;
+            private readonly int _agentSize;
+
+            // The cell buffer is pinned for the whole search because the open set holds raw pointers into it
+            // that must stay valid across ticks.
+            private GCHandle _handle;
+            private Cell* _cells;
+            private bool _pinned;
+
+            // Every cell ever discovered (in grid order of discovery). _seen[index] guards against duplicates.
+            private readonly List<Coordinate> _discovered = new List<Coordinate>();
+            private readonly bool[] _seen;
+
+            private SearchState _state;
+            private int _iteration;
+            private Coordinate _current;
+            private SearchStep _lastStep;
+            private bool _disposed;
+
+            internal StepwiseSearch(Pathfinder pathfinder, IAgent agent, Coordinate from, Coordinate to)
+            {
+                _pathfinder = pathfinder;
+                _to = to;
+                _agentSize = agent.Size;
+
+                // Flatten the caller's grid representation into _cells before we take a pointer to it,
+                // exactly as GetPath does.
+                pathfinder.InitializeCellsArray();
+
+                try
+                {
+                    _handle = GCHandle.Alloc(pathfinder._cells, GCHandleType.Pinned);
+                    _pinned = true;
+                    _cells = (Cell*)_handle.AddrOfPinnedObject();
+
+                    pathfinder.ResetCells(_cells);
+                    pathfinder._openSet.Clear();
+
+                    _seen = new bool[pathfinder.Size];
+
+                    // Seed the open set with the origin, mirroring CalculatePath. ScoreH is set purely so the
+                    // start node reports a consistent f = g + h when visualized; it does not affect the search.
+                    var start = pathfinder.GetCell(_cells, from.X, from.Y);
+                    start->ScoreH = pathfinder.GetH(from.X, from.Y, to.X, to.Y);
+                    pathfinder._openSet.Enqueue(start, start->ScoreH);
+                    MarkDiscovered(start);
+
+                    _state = SearchState.InProgress;
+                    _current = from;
+                    _lastStep = BuildStep(Array.Empty<Coordinate>());
+                }
+                catch
+                {
+                    ReleaseHandle();
+                    throw;
+                }
+            }
+
+            /// <summary>
+            /// Gets the overall state of the search.
+            /// </summary>
+            public SearchState State => _state;
+
+            /// <summary>
+            /// Gets a value indicating whether the search has finished (succeeded or failed).
+            /// </summary>
+            public bool IsComplete => _state != SearchState.InProgress;
+
+            /// <summary>
+            /// Gets the number of expansions performed so far.
+            /// </summary>
+            public int Iteration => _iteration;
+
+            /// <summary>
+            /// Advances the search by expanding a single cell and returns a snapshot of the search afterwards.
+            /// Once the search is complete this is a no-op that returns the final snapshot again.
+            /// </summary>
+            /// <returns>A <see cref="SearchStep"/> describing the accumulated searched area and, on success, the path.</returns>
+            /// <exception cref="ObjectDisposedException">Thrown when the session has been disposed.</exception>
+            public SearchStep Tick()
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(StepwiseSearch));
+                }
+
+                if (_state != SearchState.InProgress)
+                {
+                    return _lastStep;
+                }
+
+                if (_pathfinder._openSet.Count == 0)
+                {
+                    // Frontier exhausted without reaching the destination: no path exists.
+                    _state = SearchState.Failure;
+                    return _lastStep = BuildStep(Array.Empty<Coordinate>());
+                }
+
+                _iteration++;
+
+                var neighbors = stackalloc Cell*[MaxNeighbors];
+                var reachedGoal = _pathfinder.ExpandNext(_cells, _to, _agentSize, neighbors, out var current);
+                _current = current->Coordinate;
+
+                if (reachedGoal)
+                {
+                    _state = SearchState.Success;
+                    return _lastStep = BuildStep(TracePath(current));
+                }
+
+                // The expansion may have discovered new frontier cells; record them.
+                for (var n = 0; n < MaxNeighbors; n++)
+                {
+                    var neighbor = neighbors[n];
+                    if (neighbor != null)
+                    {
+                        MarkDiscovered(neighbor);
+                    }
+                }
+
+                return _lastStep = BuildStep(Array.Empty<Coordinate>());
+            }
+
+            /// <summary>
+            /// Advances the search until it completes and returns the final snapshot. Equivalent to calling
+            /// <see cref="Tick"/> in a loop until <see cref="IsComplete"/> is true.
+            /// </summary>
+            /// <returns>The final <see cref="SearchStep"/> (a success or failure snapshot).</returns>
+            /// <exception cref="ObjectDisposedException">Thrown when the session has been disposed.</exception>
+            public SearchStep RunToCompletion()
+            {
+                var step = _lastStep;
+                while (!IsComplete)
+                {
+                    step = Tick();
+                }
+
+                return step;
+            }
+
+            private void MarkDiscovered(Cell* cell)
+            {
+                var index = (int)(cell - _cells);
+                if (_seen[index])
+                {
+                    return;
+                }
+
+                _seen[index] = true;
+                _discovered.Add(cell->Coordinate);
+            }
+
+            /// <summary>
+            /// Reconstructs the raw A* path (parent-pointer chain) into a plain array. Mirrors
+            /// <see cref="Pathfinder.ReconstructPath"/> but without pooling or smoothing, and — like it — excludes
+            /// the origin cell.
+            /// </summary>
+            private Coordinate[] TracePath(Cell* lastCell)
+            {
+                var depth = lastCell->Depth;
+                var path = new Coordinate[depth];
+
+                var current = lastCell;
+                for (var i = depth - 1; i >= 0; i--)
+                {
+                    path[i] = current->Coordinate;
+                    var parent = current->ParentCoordinate;
+                    current = _pathfinder.GetCell(_cells, parent.X, parent.Y);
+                }
+
+                return path;
+            }
+
+            private SearchStep BuildStep(Coordinate[] path)
+            {
+                var count = _discovered.Count;
+                var searched = new SearchNode[count];
+                var openCount = 0;
+
+                for (var i = 0; i < count; i++)
+                {
+                    var coordinate = _discovered[i];
+                    var cell = _pathfinder.GetCell(_cells, coordinate.X, coordinate.Y);
+                    var nodeState = cell->IsClosed ? SearchNodeState.Closed : SearchNodeState.Open;
+
+                    if (nodeState == SearchNodeState.Open)
+                    {
+                        openCount++;
+                    }
+
+                    searched[i] = new SearchNode(coordinate, nodeState,
+                        cell->ScoreG, cell->ScoreH, cell->ScoreF);
+                }
+
+                return new SearchStep(_state, _iteration, _current, searched, openCount, count - openCount, path);
+            }
+
+            private void ReleaseHandle()
+            {
+                if (!_pinned)
+                {
+                    return;
+                }
+
+                _handle.Free();
+                _pinned = false;
+                _cells = null;
+            }
+
+            /// <summary>
+            /// Releases the pinned cell buffer and frees the owning <see cref="Pathfinder"/> for other queries.
+            /// </summary>
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                ReleaseHandle();
+                _pathfinder._searchSessionActive = false;
+            }
+        }
+    }
+}

--- a/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Stepwise.cs.meta
+++ b/src/mpath-unity-project/Packages/MPath/Source/Pathfinder_Stepwise.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2f21c518bcd4a7fbd34ec0e6cb05d41


### PR DESCRIPTION
## What

Adds a **stepwise** (tick-by-tick) variant of the A* search for **displaying how the pathfinder works** — an educational/visualization facility that does not replace or change `GetPath`.

`Pathfinder.BeginStepwiseSearch(agent, from, to)` returns a disposable `Pathfinder.StepwiseSearch`. Each `Tick()` performs a single cell expansion and returns an immutable `SearchStep` snapshot containing:

- the **accumulated searched area** — every discovered cell tagged `Open` (frontier) or `Closed` (expanded), each with its A* `g`/`h`/`f` scores,
- `Current` (the cell expanded this tick), `OpenCount`/`ClosedCount`, and
- the **path** once the destination is reached.

`RunToCompletion()` advances to the end in one call.

```csharp
using var search = pathfinder.BeginStepwiseSearch(agent, from, to);
while (!search.IsComplete)
{
    var step = search.Tick();
    Render(step.Searched); // open vs closed cells, with scores
}
```

## Why this design

The request asked for a `Tick`-style API that shows the flow **without changing how the pathfinder works today** and **without duplicating code** — and floated "a separate class that inherits from `Pathfinder`".

- **No subclassing.** `Pathfinder` is `sealed` and its algorithm internals are `private`; inheriting would force unsealing it and exposing unsafe pointer internals as `protected`. Instead the driver is a **public nested `Pathfinder.StepwiseSearch`**, which reuses every private helper directly.
- **No duplicated logic.** A single A* iteration is factored into a shared private `ExpandNext`, called by both the batch `GetPath` loop and the stepwise search — so they run identical expansion logic and find the same path. `ExpandNext` is `AggressiveInlining`, keeping `GetPath`'s hot path unchanged (a pure, behavior-preserving refactor; the existing 100 tests still pass).
- **Correctness over speed**, as requested for this path: the session pins the cell buffer (`GCHandle`) for the search lifetime so the open set's raw pointers stay valid across ticks — hence it is `IDisposable` and locks the instance to one active session (`InvalidOperationException` on a second). Snapshots own plain arrays (no pooling) so they survive across ticks.

The visualized `Path` is the **raw** A* path (no smoothing), following `PathResult`'s origin-excluded convention.

### New public types
`Pathfinder.StepwiseSearch`, `SearchStep`, `SearchNode`, `SearchState`, `SearchNodeState`.

## Verification
- `dotnet build src/mpath-source/Migs.MPath.sln` — **0 errors**.
- `dotnet test …/Migs.MPath.Tests.csproj` — **115 passed** (100 existing + **15 new** stepwise tests covering path equivalence with `GetPath`, monotonic accumulation, open/closed partitioning, failure on unreachable targets, origin==destination, idempotent/disposed ticks, the single-session guard, and argument validation).

## Docs
- New `docs/api/` pages: `StepwiseSearch`, `SearchStep`, `SearchNode`, `SearchState` (+ index).
- New guide `docs/guides/visualizing-search.md` (+ `docs/README.md` index).
- `docs/api/Pathfinder.md`, `README.md`, and `CLAUDE.md` updated for the new public surface and architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)